### PR TITLE
Fixed issue with footprint filter shuffling dataframe.

### DIFF
--- a/surveySimPP.py
+++ b/surveySimPP.py
@@ -259,6 +259,11 @@ def runPostProcessing():
             
             observations=observations.iloc[onSensor]
             observations["detectorID"] = detectorIDs
+            
+            # observations dataframe is now shuffled in object ID, which causes problems
+            # when applying SSP criterion efficiency.
+            
+            observations = observations.sort_index()
         
             #oif=oif.astype({"FieldID": int})
             #surveydb=surveydb.astype({"observationId": int})


### PR DESCRIPTION
Applying the camera footprint filter shuffles the observations dataframe in object ID. This causes issues with PPFilterSSPCriterionEfficiency, which expects a dataframe sorted by object ID. 

Fixed this quickly by adding a line after footprint filter application to resort the observations dataframe on its integer index, which restores the previous order. Computational load should not be high for sensible chunk sizes.