### PR TITLE
Added early merge with pointing, other small fixes

### DIFF
--- a/modules/PPMatchPointingToObservations.py
+++ b/modules/PPMatchPointingToObservations.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python
+
+import pandas as pd
+import numpy as np
+import logging
+import sys
+
+# Author: Steph Merritt (based on Grigori's PPMatchPointingAndColours)
+
+def PPMatchFilterToObservations(padain, pointfildb):
+	"""
+	Description: Merges the filter information of each observation from the pointing
+	database onto the observations dataframe, then drops all observations which are not
+	in one of the requested filters and any duplicate columns.
+
+	Mandatory input:      Output from objectsInField (oif) or similar (pandas dataframe)
+						  Pointing and filter dataframe (pandas dataframe)
+
+	Output:               pandas dataframe
+
+
+	usage: padafr=PPMatchFilterToObservations(padain,pointfildb)
+
+	"""
+
+	resdf = pd.merge(padain, pointfildb[["FieldID", "optFilter", "observationStartMJD"]], 
+						left_on="FieldID", 
+						right_on="FieldID", 
+						how="left")
+
+	colour_values=resdf.optFilter.unique()
+	colour_values=pd.Series(colour_values).dropna()
+
+	resdf=resdf.dropna(subset=['optFilter']).reset_index(drop=True)
+
+	chktruemjd=np.isclose(resdf['observationStartMJD'], resdf['FieldMJD'])
+
+	if not chktruemjd.all():
+		logging.error('ERROR: PPMatchFilterToObservations: mismatch in pointing database and pointing output times.')
+		sys.exit('ERROR:: PPMatchFilterToObservations: mismatch in pointing database and pointing output times.')
+
+	resdf = resdf.drop(columns='observationStartMJD')
+
+	return resdf
+
+	
+def PPMatchPointingToObservations(padain, pointfildb):
+	"""
+	Description: Merges all relevant columns of each observation from the pointing
+	database onto the observations dataframe, then drops all observations which are not
+	in one of the requested filters and any duplicate columns.
+
+	Mandatory input:      Output from objectsInField (oif) or similar (pandas dataframe)
+						  Pointing and filter dataframe (pandas dataframe)
+
+	Output:               pandas dataframe
+
+
+	usage: padafr=PPMatchFilterToObservations(padain,pointfildb)
+
+	"""
+
+	resdf = pd.merge(padain, pointfildb, 
+					left_on="FieldID", 
+					right_on="FieldID", 
+					how="left")
+
+	colour_values=resdf.optFilter.unique()
+	colour_values=pd.Series(colour_values).dropna()
+
+	resdf=resdf.dropna(subset=['optFilter']).reset_index(drop=True)
+
+	chktruemjd=np.isclose(resdf['observationStartMJD'], resdf['FieldMJD'])
+
+	if not chktruemjd.all():
+	   logging.error('ERROR: PPMatchFilterToObservations: mismatch in pointing database and pointing output times.')
+	   sys.exit('ERROR:: PPMatchFilterToObservations: mismatch in pointing database and pointing output times.')
+   
+	resdf = resdf.drop(columns=['observationStartMJD', "observationId_"])
+
+	return resdf


### PR DESCRIPTION
- I have written two functions contained in PPMatchPointingToObservations.py. PPMatchFilterToObservations merges the filters from _filterpointing_ onto _observations_. PPMatchPointingToObservations merges all columns from _filterpointing_ onto _observations_. In both cases, observations from filters that were not specified in the config file are dropped. I've also added these functions to surveySimPP.py, but **commented out**, as they don't work with the current form of PPCalculateApparentMagnitude (as it tries to do a similar merge). We should use one or the other. PPMatchFilterToObservations satisfies issue #64 and #84. PPMatchPointingToObservations will satisfy issue #66 as well. Recommend PPCalculateApparentMagnitude be rewritten to take output from PPMatchPointingToObservations.
- Random number generator on line 89 is now instantiated with the system time as a seed, which is saved to the log. Note that np.random.default_rng() requires an int as the seed, so I've had to round the system time to the nearest second. See issue #63. 
- Removed PPMatchPointing as unneccessary and changed the only reference to its product to take _filterpointing_ instead: see issue #70.
- Removed unnecessary line from code as per issue #68.