### PR TITLE
Made changes to application of footprint filter.

### DIFF
--- a/surveySimPP/modules/PPApplyFootprint.py
+++ b/surveySimPP/modules/PPApplyFootprint.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+
+from . import PPFootprintFilter
+import logging
+
+
+def PPApplyFootprint(observations, configs):
+
+    """
+    PPApplyFootprint.py
+
+ 
+    """
+
+    pplogger = logging.getLogger(__name__)
+    
+    if (configs['cameraModel'] == "circle"):
+        pplogger.info('Applying detection efficiency threshold...')
+        observations=PPFilterDetectionEfficiencyThreshold.PPFilterDetectionEfficiencyThreshold(observations,configs['SSPDetectionEfficiency'])
+
+    elif (configs['cameraModel'] == "footprint"):
+        pplogger.info('Applying sensor footprint filter...')
+        footprintf = PPFootprintFilter.Footprint(configs['footprintPath'])
+        onSensor, detectorIDs = footprintf.applyFootprint(observations)
+
+        observations=observations.iloc[onSensor].copy()
+        observations["detectorID"] = detectorIDs
+
+        observations = observations.sort_index()
+
+    return observations
+        
+        

--- a/surveySimPP/modules/__init__.py
+++ b/surveySimPP/modules/__init__.py
@@ -33,3 +33,4 @@ from . import PPTrailingLoss
 from . import PPTranslateMagnitude
 from . import PPVignetting
 from . import PPRunUtilities
+from . import PPApplyFootprint


### PR DESCRIPTION
The application of the footprint filter is now treated as its own filter and has been wrapped up into a new function, PPApplyFootprint. The if statement checking for what the cameraModel is set to has been removed from surveySimPP.py and now all filters are applied regardless of whether cameraModel is 'footprint' or 'circle'. This solves issue #106. 

Additionally, Footprint.applyFootprint  has been rewritten to remove the unnecessary merge of the observations with the pointing database. This closes issue #66, as Footprint.applyFootprint was the last function/method left that actually uses the pointing database, but issue #81 still needs fixing.

I think I have set this up so that it doesn't break the pip install, it works okay on my machine.

