### PR TITLE
Fixed chunking (#75), also minor bug in PPSNRLimit.py

### DIFF
--- a/surveySimPP/modules/PPSNRLimit.py
+++ b/surveySimPP/modules/PPSNRLimit.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-def PPSNRLimit(observations, sigma_limit=2.):
+def PPSNRLimit(obs, sigma_limit=2.):
     """
     PPSNRLimit.py
     
@@ -23,8 +23,10 @@ def PPSNRLimit(observations, sigma_limit=2.):
     observations: Pandas dataframe as input but with entries under the SNR limit removed.
     
     """
-
-    observations.drop( np.where(observations["SNR"] <= sigma_limit)[0], inplace=True)
-    observations.reset_index(drop=True, inplace=True)
     
-    return observations
+    obs.reset_index(inplace=True)
+    rows_to_drop = np.where(obs["SNR"] <= sigma_limit)[0]   
+    observations_dropped = obs.drop(index=rows_to_drop)
+    observations_dropped.reset_index(drop=True, inplace=True)
+    
+    return observations_dropped

--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -77,7 +77,7 @@ def runLSSTPostProcessing(cmd_args):
             pass
     lenf=ii
     
-    while(endChunk <= lenf):
+    while(endChunk < lenf):
         endChunk=startChunk + configs['sizeSerialChunk'] 
         if (lenf-startChunk > configs['sizeSerialChunk']):
              incrStep=configs['sizeSerialChunk']
@@ -110,6 +110,8 @@ def runLSSTPostProcessing(cmd_args):
         pplogger.info('Calculating astrometric and photometric uncertainties...')
         observations['AstrometricSigma(mas)'], observations['PhotometricSigma(mag)'], observations["SNR"] = PPAddUncertainties.uncertainties(observations)
         observations["AstrometricSigma(deg)"] = observations['AstrometricSigma(mas)'] / 3600. / 1000.
+        
+        #PPWriteOutput(configs, observations, endChunk)
     
         pplogger.info('Dropping observations with signal to noise ratio less than 2...')
         observations = PPSNRLimit(observations)


### PR DESCRIPTION
Fixes #75.

Took the equals sign out of the while loop for chunking. That fixed it. Chunking now works as intended.

Also discovered that PPSNRLimit.py was breaking, either because I didn't test it properly (sorry!) or because a recent change disordered the integer axis on the observations dataframe. It's fixed now.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
