### PR TITLE
Fixing config file issues.

### DIFF
--- a/demo/PPConfig.ini
+++ b/demo/PPConfig.ini
@@ -77,7 +77,7 @@ SSPDetectionEfficiency = 0.95
 
 # Fraction of detector surface area which contains CCD -- simulates chip gaps
 # default = 0.9
-fillfactor = 0.9
+# fillfactor = 0.9
 
 # length of trackets: default == 2. How many observations during one night are required to produce 
 # a valid tracklet? 
@@ -91,15 +91,16 @@ noTracklets = 3
 # number of tracklets needs to be discovered to constitute a complete detection?
 trackletInterval = 15.0
 
+# minimum separation for SSP inside the tracklet (in arcseconds) to distinguish between 
+# two images to recognise the motion between images (default == 0.5)
+inSepThreshold = 0.5
 
 # Limit of brightness: detection with brightness higher than this are omitted (assuming satueration)
 # default == 16.0
 brightLimit = 16.0
 
-
-# minimum separation for SSP inside the tracklet (in arcseconds) to distinguish between 
-# two images to recognise the motion between images (default == 0.5)
-inSepThreshold = 0.5
+# SNR limit: drop observations below this SNR threshold. omit for no SNR cut.
+SNRlimit = 2.0
 
 #### COLOURS ####
 


### PR DESCRIPTION
Fixes #169.
Fixes #116.
Fixes #115.
Fixes #153.

The SNR limit is now a variable in the config file.

If the brightness limit, SNR limit or SSP-related variables are not included in the config file, this essentially turns those filters off. If only some of the four variables needed for the SSP filter are supplied, it errors out gracefully.

If fillfactor is supplied and camera model is "footprint", the code fails gracefully.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
