### PR TITLE
Issues #102, #164, and PEP8 fixes.

### DIFF
--- a/demo/PPConfig.ini
+++ b/demo/PPConfig.ini
@@ -95,7 +95,7 @@ brightLimit = 16.0
 # Detection efficiency fading function on or off. Uses the fading function as outlined in 
 # Chelsey and Vereš (2017) to remove observations. 
 # Default: True.
-fadingFunctionOn = False
+fadingFunctionOn = True
 
 
 # Below are FIVE variables needed to run the SSP linking filter. Comment all
@@ -139,9 +139,12 @@ sizeSerialChunk = 10
 # -u or --outfile                   Output file path.
 # -t or --stem                      Output file stem.
 
-# options [csv  | separatelyCSV| sqlite3 | hdf5 ]
+# Output format. Options [csv  | separatelyCSV | sqlite3 | hdf5 ].
 outputformat = csv
 
+# Size of output. Controls which columns are in the output files. 
+# Options are "default" only. More may be added later.
+outputsize = default
 
 
 

--- a/surveySimPP/modules/PPBrightLimit.py
+++ b/surveySimPP/modules/PPBrightLimit.py
@@ -1,27 +1,25 @@
 #!/usr/bin/python
 
-import pandas as pd
-
-#Author: Grigori Fedorets
+# Author: Grigori Fedorets
 
 def PPBrightLimit(padain, brlimit):
 
-   """
-   Task: PPBrightLimit
-    
-   Description: Goes through every row in pandas dataframe and drops lines the ColinFil
-   of which is brighter than the defined magnitude.
-    
-    
-   Input: padain: pandas dataframe
-   upperlimit: float, upper limit for ColinFil column value in padain dataframe
-    
+    """
+    Task: PPBrightLimit
 
-   Output: pandas dataframe (modified)
-    
-   
-   """
-   padain = padain.drop(padain[padain.TrailedSourceMag < brlimit].index)
-   padain.reset_index(drop=True, inplace=True)
-   
-   return padain
+    Description: Goes through every row in pandas dataframe and drops lines the ColinFil
+    of which is brighter than the defined magnitude.
+
+
+    Input: padain: pandas dataframe
+    upperlimit: float, upper limit for ColinFil column value in padain dataframe
+
+
+    Output: pandas dataframe (modified)
+
+
+    """
+    padain = padain.drop(padain[padain.TrailedSourceMag < brlimit].index)
+    padain.reset_index(drop=True, inplace=True)
+
+    return padain

--- a/surveySimPP/modules/PPCalculateApparentMagnitude.py
+++ b/surveySimPP/modules/PPCalculateApparentMagnitude.py
@@ -3,42 +3,42 @@
 from . import PPCalculateApparentMagnitudeInFilter, PPResolveMagnitudeInFilter
 from . import PPCalculateSimpleCometaryMagnitude
 import logging
-import pandas as pd
 
 # Author: Grigori Fedorets
+
 
 def PPCalculateApparentMagnitude(observations, phasefunction, mainfilter, othercolours, observing_filters, object_type):
 
     """
     PPCalculateApparentMagnitude(observations, phasefunction, mainfilter, othercolours, observing_filters)
-    
+
     This task combines calculating the apparent magnitude in the main filter, combining the brightness information with
     colours for appropriate filter, and then, finally, selecting the correct colour and applying the correct offset.
- 
+
     Input: observations   : pandas DataFrame
            phasefunction  : string
            mainfilter     : string
            othercolours   : array of strings
            observing_filters     : array of strings
-   
+
     Output: observations: amended pandas DataFrame
- 
+
     Usage: observations=PPCalculateApparentMagnitude(observations, phasefunction, mainfilter, othercolours, observing_filters)
     """
-    
+
     pplogger = logging.getLogger(__name__)
- 
+
     pplogger.info('Calculating apparent magnitudes...')
-    observations=PPCalculateApparentMagnitudeInFilter.PPCalculateApparentMagnitudeInFilter(observations, phasefunction, mainfilter)
-    
-    if (object_type =='comet'):
-         pplogger.info('Calculating cometary magnitude using a simple model...')
-         observations=PPCalculateSimpleCometaryMagnitude.PPCalculateSimpleCometaryMagnitude(observations, mainfilter)         
-    
+    observations = PPCalculateApparentMagnitudeInFilter.PPCalculateApparentMagnitudeInFilter(observations, phasefunction, mainfilter)
+
+    if (object_type == 'comet'):
+        pplogger.info('Calculating cometary magnitude using a simple model...')
+        observations = PPCalculateSimpleCometaryMagnitude.PPCalculateSimpleCometaryMagnitude(observations, mainfilter)
+
     pplogger.info('Selecting and applying correct colour offset...')
-    observations=PPResolveMagnitudeInFilter.PPResolveMagnitudeInFilter(observations,mainfilter,othercolours,observing_filters)
-    
+    observations = PPResolveMagnitudeInFilter.PPResolveMagnitudeInFilter(observations, mainfilter, othercolours, observing_filters)
+
     observations_drop = observations.drop(mainfilter, axis=1)
     observations_drop.reset_index(drop=True, inplace=True)
-    
+
     return observations_drop

--- a/surveySimPP/modules/PPCalculateApparentMagnitudeInFilter.py
+++ b/surveySimPP/modules/PPCalculateApparentMagnitudeInFilter.py
@@ -1,157 +1,146 @@
 #!/usr/bin/python
 
-import os, sys
-import pandas as pd
-from numpy import pi, tan, log10, exp, power
+import sys
+from numpy import log10
 import astropy.units as u
-import sbpy
 from sbpy.photometry import HG, HG1G2, HG12_Pen16, LinearPhaseFunc
 import logging
 
-
 # Author: Grigori Fedorets
 
+
 def PPCalculateApparentMagnitudeInFilter(padain, function, mainfilter):
-
-
     """
     PPCalculateApparentMagnitudeInFilter.py
-    
-    Description: This task calculates the apparent brightness of an 
+
+    Description: This task calculates the apparent brightness of an
     object in the mail filter (as defined in the config file) at a given pointing
     according to one of the following photometric phase function models:
           HG:                Bowell et al. (1989) Asteroids II book.
           HG1G2:             Muinonen et al. (2010) Icarus 209 542.
           HG12:              Penttilä et al. (2016) PSS 123 117.
           linear             (as implemented in sbpy)
-    
+
     The brightness is here calculated in the main filter, and the colour offset is
     applied later using the PPhookBrightnessWithColour function.
-    
+
     The function makes use of the implementations in the sbpy library.
-    
-    Mandatory input:      string, padain, name of input pandas daraframe  
+
+    Mandatory input:      string, padain, name of input pandas dataframe
                           string, function, selected photometric phase function
-                                  (HG, HG1G2, HG12, linear) 
+                                  (HG, HG1G2, HG12, linear)
                           string, mainfilter, name of the main filter in which
                                   the brightness is calculated
 
-    Output:        updated padain       
-      
+    Output:        updated padain
+
     usage: padaout=PPCalculateApparentMagnitudeInFilter(padain, function, mainfilter):
 
     """
-    
+
     pplogger = logging.getLogger(__name__)
-    
+
     # first, calculate rho, delta and phase
-    
-    padain['rho']=padain['AstRange(km)']/1.495978707e8
+
+    padain['rho'] = padain['AstRange(km)'] / 1.495978707e8
     # r is usually the colour, hence somewhat unconventional rho
-    padain['delta']=((padain['Ast-Sun(J2000x)(km)']*padain['Ast-Sun(J2000x)(km)'] \
-               + padain['Ast-Sun(J2000y)(km)']*padain['Ast-Sun(J2000y)(km)'] \
-               + padain['Ast-Sun(J2000z)(km)']*padain['Ast-Sun(J2000z)(km)']).pow(1./2))/1.495978707e8 
+    padain['delta'] = ((padain['Ast-Sun(J2000x)(km)'] * padain['Ast-Sun(J2000x)(km)']
+                        + padain['Ast-Sun(J2000y)(km)'] * padain['Ast-Sun(J2000y)(km)']
+                        + padain['Ast-Sun(J2000z)(km)'] * padain['Ast-Sun(J2000z)(km)']).pow(1./2)) / 1.495978707e8
 
-    padain['phase']=padain['Sun-Ast-Obs(deg)']#*pi/180.0
-        
+    padain['phase'] = padain['Sun-Ast-Obs(deg)']  # *pi/180.0
 
-    if (function=='HG1G2'):
-        if set(['H','G1','G2']).issubset(padain.columns):        
-              Harr=padain['H'].values
-              G1arr = padain['G1'].values
-              G2arr = padain['G2'].values
-              pharr= padain['phase'].values
-              phfarr=[]
-              for i in range(len(padain.index)):
-                  HGm=HG1G2(H=Harr[i]*u.mag, G1=G1arr[i], G2=G2arr[i])
-                  phf=HGm(pharr[i]*u.deg)
-                  phfarr.append(phf.value)
-              padain['phase_function']=phfarr
-              # in sbpy, phase_function = H(alpha) + Phi(alpha)
-              padain[mainfilter] =  5.*log10(padain['delta']) + 5.*log10(padain['rho']) + padain['phase_function']
-              padain=padain.drop(['delta', 'rho', 'phase', 'phase_function'], axis = 1)
-        
+    if (function == 'HG1G2'):
+        if set(['H', 'G1', 'G2']).issubset(padain.columns):
+            Harr = padain['H'].values
+            G1arr = padain['G1'].values
+            G2arr = padain['G2'].values
+            pharr = padain['phase'].values
+            phfarr = []
+            for i in range(len(padain.index)):
+                HGm = HG1G2(H=Harr[i] * u.mag, G1=G1arr[i], G2=G2arr[i])
+                phf = HGm(pharr[i] * u.deg)
+                phfarr.append(phf.value)
+            padain['phase_function'] = phfarr
+            # in sbpy, phase_function = H(alpha) + Phi(alpha)
+            padain[mainfilter] = 5. * log10(padain['delta']) + 5. * log10(padain['rho']) + padain['phase_function']
+            padain = padain.drop(['delta', 'rho', 'phase', 'phase_function'], axis=1)
+
         else:
-           pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: HG1G2 function requires the following input data columns: H, G1, G2.')
-           sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: HG1G2 function requires the following input data columns: H, G1, G2.')
-           
-    elif (function=='HG'):
-         if set(['H', 'GS']).issubset(padain.columns):
-              Harr=padain['H'].values
-              Garr = padain['GS'].values
-              pharr= padain['phase'].values
-              phfarr=[]
-              for i in range(len(padain.index)):
-                  HGm=HG(H=Harr[i]*u.mag, G=Garr[i])
-                  phf=HGm(pharr[i]*u.deg)
-                  phfarr.append(phf.value)
-              padain['phase_function']=phfarr
-              # in sbpy, phase_function = H(alpha) + Phi(alpha)
-              padain[mainfilter] =  padain['phase_function'] + 5.*log10(padain['delta']) + 5.*log10(padain['rho'])  
-              padain=padain.drop(['delta', 'rho', 'phase', 'phase_function'], axis = 1)
-              
-         else:
-              pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: HG function requires the following input data columns: H, GS.')
-              sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: HG function requires the following input data columns: H, GS.')
-           
+            pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: HG1G2 function requires the following input data columns: H, G1, G2.')
+            sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: HG1G2 function requires the following input data columns: H, G1, G2.')
 
-    
-    elif (function=='HG12'):
+    elif (function == 'HG'):
+        if set(['H', 'GS']).issubset(padain.columns):
+            Harr = padain['H'].values
+            Garr = padain['GS'].values
+            pharr = padain['phase'].values
+            phfarr = []
+            for i in range(len(padain.index)):
+                HGm = HG(H=Harr[i] * u.mag, G=Garr[i])
+                phf = HGm(pharr[i] * u.deg)
+                phfarr.append(phf.value)
+            padain['phase_function'] = phfarr
+            # in sbpy, phase_function = H(alpha) + Phi(alpha)
+            padain[mainfilter] = padain['phase_function'] + 5. * log10(padain['delta']) + 5. * log10(padain['rho'])
+            padain = padain.drop(['delta', 'rho', 'phase', 'phase_function'], axis=1)
+
+        else:
+            pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: HG function requires the following input data columns: H, GS.')
+            sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: HG function requires the following input data columns: H, GS.')
+
+    elif (function == 'HG12'):
         if set(['H', 'G12']).issubset(padain.columns):
-              Harr=padain['H'].values
-              G12arr = padain['G12'].values
-              pharr= padain['phase'].values
-              phfarr=[]
-              for i in range(len(padain.index)):
-                  HGm=HG12_Pen16(H=Harr[i]*u.mag, G12=G12arr[i])
-                  phf=HGm(pharr[i]*u.deg)
-                  phfarr.append(phf.value)
-              padain['phase_function']=phfarr
-              # in sbpy, phase_function = H(alpha) + Phi(alpha)
-              padain[mainfilter] =  5.*log10(padain['delta']) + 5.*log10(padain['rho']) + padain['phase_function']
-              padain=padain.drop(['delta', 'rho', 'phase', 'phase_function'], axis = 1)
-                
+            Harr = padain['H'].values
+            G12arr = padain['G12'].values
+            pharr = padain['phase'].values
+            phfarr = []
+            for i in range(len(padain.index)):
+                HGm = HG12_Pen16(H=Harr[i] * u.mag, G12=G12arr[i])
+                phf = HGm(pharr[i] * u.deg)
+                phfarr.append(phf.value)
+            padain['phase_function'] = phfarr
+            # in sbpy, phase_function = H(alpha) + Phi(alpha)
+            padain[mainfilter] = 5. * log10(padain['delta']) + 5. * log10(padain['rho']) + padain['phase_function']
+            padain = padain.drop(['delta', 'rho', 'phase', 'phase_function'], axis=1)
+
         else:
-              pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: HG12 function requires the following input data columns: H, G12.')
-              sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: HG12 function requires the following input data columns: H, G12.')
-    
-    
-    elif (function=='linear'):
+            pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: HG12 function requires the following input data columns: H, G12.')
+            sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: HG12 function requires the following input data columns: H, G12.')
+
+    elif (function == 'linear'):
         if set(['H', 'S']).issubset(padain.columns):
-        
-              Harr=padain['H'].values
-              Sarr = padain['S'].values
-              pharr= padain['phase'].values
-              phfarr=[]
-              for i in range(len(padain.index)):
-                  HGm=LinearPhaseFunc(H=Harr[i]*u.mag, S=Sarr[i]*u.mag/u.deg)
-                  phf=HGm(pharr[i]*u.deg)
-                  phfarr.append(phf.value)
-              padain['phase_function']=phfarr
-              # in sbpy, phase_function = H(alpha) + Phi(alpha)
-              padain[mainfilter] =  5.*log10(padain['delta']) + 5.*log10(padain['rho']) + padain['phase_function'] 
-              padain=padain.drop(['delta', 'rho', 'phase', 'phase_function'], axis = 1)
-        
+            Harr = padain['H'].values
+            Sarr = padain['S'].values
+            pharr = padain['phase'].values
+            phfarr = []
+            for i in range(len(padain.index)):
+                HGm = LinearPhaseFunc(H=Harr[i] * u.mag, S=Sarr[i] * u.mag / u.deg)
+                phf = HGm(pharr[i] * u.deg)
+                phfarr.append(phf.value)
+            padain['phase_function'] = phfarr
+            # in sbpy, phase_function = H(alpha) + Phi(alpha)
+            padain[mainfilter] = 5. * log10(padain['delta']) + 5. * log10(padain['rho']) + padain['phase_function']
+            padain = padain.drop(['delta', 'rho', 'phase', 'phase_function'], axis=1)
+
         else:
-              pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: linear function requires the following input data columns: H, S.')
-              sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: linear function requires the following input data columns: H, S.')
-    
-    
-    elif (function=='none'):
+            pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: linear function requires the following input data columns: H, S.')
+            sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: linear function requires the following input data columns: H, S.')
+
+    elif (function == 'none'):
         # Assuming only H
         if set(['H']).issubset(padain.columns):
-             padain[mainfilter] =  5.*log10(padain['delta']) + 5.*log10(padain['rho']) + padain['H']
-             padain=padain.drop(['delta', 'rho', 'phase'], axis = 1)
+            padain[mainfilter] = 5. * log10(padain['delta']) + 5. * log10(padain['rho']) + padain['H']
+            padain = padain.drop(['delta', 'rho', 'phase'], axis=1)
 
         else:
-              pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: none function requires the following input data columns: H.')
-              sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: none function requires the following input data columns: H.')
-             
-    
-    else:
-         pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: unknown phase function. Should be HG1G2, HG, HG12 or linear.')
-         sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: unknown phase function. Should be HG1G2, HG, HG12 or linear.')
+            pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: none function requires the following input data columns: H.')
+            sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: none function requires the following input data columns: H.')
 
-    padain=padain.reset_index(drop=True)
+    else:
+        pplogger.error('ERROR: PPCalculateApparentMagnitudeInFilter: unknown phase function. Should be HG1G2, HG, HG12 or linear.')
+        sys.exit('ERROR: PPCalculateApparentMagnitudeInFilter: unknown phase function. Should be HG1G2, HG, HG12 or linear.')
+
+    padain = padain.reset_index(drop=True)
 
     return padain

--- a/surveySimPP/modules/PPCalculateSimpleCometaryMagnitude.py
+++ b/surveySimPP/modules/PPCalculateSimpleCometaryMagnitude.py
@@ -1,52 +1,48 @@
 #!/usr/bin/python
 
 from surveySimPP.lsstcomet import Comet
-from math import sqrt
-import pandas as pd
 import numpy as np
 
 # Author: Grigori Fedorets
-# Using lsstcomet code my Mike Kelley
+# Using lsstcomet code by Mike Kelley
 # (C)  LSST Solar System Scientific Collaboration 2019
+
 
 def PPCalculateSimpleCometaryMagnitude(padain, mainfilter):
     """
     PPCalculateSimpleCometaryMagnitude.py
-    
+
     Description: This task calculates the brightness of the comet at a given pointing
     according to a simple model by A'Hearn et al. (1984).
-    
+
     The brightness is here calculated in the main filter, and the colour offset is
     applied later using the PPhookBrightnessWithColour function.
-    
-    Mandatory input:      string, padain, name of input pandas daraframe   
+
+    Mandatory input:      string, padain, name of input pandas dataframe
                           string, mainfilter, name of the main filter in which
                                   the brightness is calculated
 
-    Output:               
-      
-    usage: padaout=PPCalculateSimpleCometaryMagnitude(padain) 
-    
-    
+    Output:
+
+    usage: padaout=PPCalculateSimpleCometaryMagnitude(padain)
+
+
     """
     # calculate rho and delta in au
-    padain['delta']=padain['AstRange(km)']/1.495978707e8
-    padain['rho']=(padain['Ast-Sun(J2000x)(km)']*padain['Ast-Sun(J2000x)(km)'] 
-               + padain['Ast-Sun(J2000y)(km)']*padain['Ast-Sun(J2000y)(km)']
-               + padain['Ast-Sun(J2000z)(km)']*padain['Ast-Sun(J2000z)(km)']).pow(1./2)/1.495978707e8 
+    padain['delta'] = padain['AstRange(km)'] / 1.495978707e8
+    padain['rho'] = (padain['Ast-Sun(J2000x)(km)'] * padain['Ast-Sun(J2000x)(km)']
+                     + padain['Ast-Sun(J2000y)(km)'] * padain['Ast-Sun(J2000y)(km)']
+                     + padain['Ast-Sun(J2000z)(km)'] * padain['Ast-Sun(J2000z)(km)']).pow(1./2) / 1.495978707e8
 
-
-    com=Comet(Hv=padain[mainfilter], afrho1=padain.afrho1, q=padain.q, k=padain.k)
+    com = Comet(Hv=padain[mainfilter], afrho1=padain.afrho1, q=padain.q, k=padain.k)
 
     g = {'rh': padain['rho'], 'delta': padain['delta'], 'phase': padain['Sun-Ast-Obs(deg)']}
     # Here, only the coma contribution is calculated in the main filter
     try:
-        padain['coma']=com.mag(g, mainfilter, rap=1, nucleus=False)
+        padain['coma'] = com.mag(g, mainfilter, rap=1, nucleus=False)
     except:
         print(g)
     # The contribution of the nucleus is taken from the absolute brightness
-    padain[mainfilter] = -2.5 * np.log10(10**(-0.4 * padain['coma']) + 10**(-0.4 * padain[mainfilter]))
+    padain[mainfilter] = -2.5 * np.log10(10 ** (-0.4 * padain['coma']) + 10 ** (-0.4 * padain[mainfilter]))
 
     return padain
-
-

--- a/surveySimPP/modules/PPCheckOrbitAndPhysicalParametersMatching.py
+++ b/surveySimPP/modules/PPCheckOrbitAndPhysicalParametersMatching.py
@@ -6,44 +6,40 @@ import sys
 
 # Author: Grigori Fedorets
 
-def PPCheckOrbitAndPhysicalParametersMatching(orbin,colin,poiin):
 
+def PPCheckOrbitAndPhysicalParametersMatching(orbin, colin, poiin):
+    """
+    PPCheckOrbitAndPhysicalParametersMatching
 
-   """
-   PPCheckOrbitAndPhysicalParametersMatching
-   
-   
-   
-   Description: Checks whether orbit and physical parameter files contain the same object id:s, and
-               additionally checks if the pointing database object id:s is a subset of 
+    Description: Checks whether orbit and physical parameter files contain the same object id:s, and
+               additionally checks if the pointing database object id:s is a subset of
                all the object id:s found in the orbit/physical parameter files.
 
 
-   Mandatory input:   pandas dataframe: orbin -- orbits
+    Mandatory input:   pandas dataframe: orbin -- orbits
                       pandas dataframe: colin -- physical parameters
                       pandas dataframe: poiin -- pointing database
-   
 
-   Output:            None; return if there is a match, throw error and quit if mismatch.
-                      
+    Output:            None; return if there is a match, throw error and quit if mismatch.
 
 
-   Usage: PPCheckOrbitAndPhysicalParametersMatching(orbin,colin,poiin)
 
-   """
-   poi=pd.unique(poiin['ObjID'])
-   poiobjs=pd.Series(poi, dtype=object)
-   
-   orbin = orbin.astype({'!!OID': object})
-   colin = colin.astype({'ObjID': object})
-   
+    Usage: PPCheckOrbitAndPhysicalParametersMatching(orbin,colin,poiin)
 
-   if orbin['!!OID'].equals(colin['ObjID']):
+    """
+
+    poi = pd.unique(poiin['ObjID'])
+    poiobjs = pd.Series(poi, dtype=object)
+
+    orbin = orbin.astype({'!!OID': object})
+    colin = colin.astype({'ObjID': object})
+
+    if orbin['!!OID'].equals(colin['ObjID']):
         if poiobjs.isin(orbin['!!OID']).all():
             return
         else:
             logging.error('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input pointing and orbit files do not match.')
             sys.exit('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input pointing and orbit files do not match.')
-   else:
-      logging.error('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input physical parameter and orbit files do not match.')
-      sys.exit('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input physical parameter and orbit files do not match.')
+    else:
+        logging.error('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input physical parameter and orbit files do not match.')
+        sys.exit('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input physical parameter and orbit files do not match.')

--- a/surveySimPP/modules/PPDetectionProbability.py
+++ b/surveySimPP/modules/PPDetectionProbability.py
@@ -21,14 +21,8 @@
 Calculate probability of detection due to fading
 
 """
-# Numpy
-import numpy as np
-# Pandas
-import pandas as pd
-#Counter
-from collections import Counter
 
-from . import PPTrailingLoss
+import numpy as np
 
 __all__ = ['PPDetectionProbability']
 
@@ -41,34 +35,37 @@ class Error(Exception):
 
     pass
 
-#-----------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------
+
+
 def calcDetectionProbability(mag, limmag, fillFactor=1.0, w=0.1):
-        """ Find the probability of a detection given a visual magnitude,
-        limiting magnitude, and fillfactor,
-        determined by the fading function from Veres & Chesley (2017).
+    """ Find the probability of a detection given a visual magnitude,
+    limiting magnitude, and fillfactor,
+    determined by the fading function from Veres & Chesley (2017).
 
-        Parameters
-        ----------
-        mag: float
-                magnitude of object in filter used for that field
-        limmag: float
-             limiting magnitude of the field
-        fillfactor: float
-             fraction of FOV covered by the camera sensor
-        w: float
-             distribution parameter
+    Parameters
+    ----------
+    mag: float
+            magnitude of object in filter used for that field
+    limmag: float
+         limiting magnitude of the field
+    fillfactor: float
+         fraction of FOV covered by the camera sensor
+    w: float
+         distribution parameter
 
-        Returns
-        -------
-        P: float
-            Probability of detection
-        """
+    Returns
+    -------
+    P: float
+        Probability of detection
+    """
 
-        P = fillFactor / (1. + np.exp((mag - limmag) / w))
+    P = fillFactor / (1. + np.exp((mag - limmag) / w))
 
-        return P
+    return P
 
-#-----------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------
+
 
 def PPDetectionProbability(oif_df, trailing_losses=False, trailing_loss_name='dmagDetect',
                            magnitude_name="TrailedSourceMag",
@@ -76,21 +73,21 @@ def PPDetectionProbability(oif_df, trailing_losses=False, trailing_loss_name='dm
                            field_id_name="FieldID",
                            fillFactor=1.0, w=0.1):
 
-        """
-        Probability of observations being observable for objectInField output.
+    """
+    Probability of observations being observable for objectInField output.
 
-        Input
-        -----
-        oif_df          ... pandas dataframe containing simulation output joined to pointing.
-        *_name          ... names of columns in oif_df
-        fillFactor      ... fraction of the field of view covered by sensors.
-        w               ... distribution parameter
-        """
+    Input
+    -----
+    oif_df          ... pandas dataframe containing simulation output joined to pointing.
+    *_name          ... names of columns in oif_df
+    fillFactor      ... fraction of the field of view covered by sensors.
+    w               ... distribution parameter
+    """
 
-
-        if (trailing_losses==False):
-            return calcDetectionProbability(oif_df[magnitude_name],oif_df[limiting_magnitude_name], fillFactor, w)
-        elif (trailing_losses==True):
-            return calcDetectionProbability(oif_df[magnitude_name] + oif_df[trailing_loss_name],oif_df[limiting_magnitude_name], fillFactor, w)
-        else:
-            print('trailing_loss has to be True or False')
+    if not trailing_losses:
+        return calcDetectionProbability(oif_df[magnitude_name], oif_df[limiting_magnitude_name], fillFactor, w)
+    elif trailing_losses:
+        return calcDetectionProbability(oif_df[magnitude_name] + oif_df[trailing_loss_name], oif_df[limiting_magnitude_name], fillFactor, w)
+    else:
+        pplogger.error('ERROR: PPDetectionProbability: trailing_losses should be True or False.')
+        sys.exit('ERROR: PPDetectionProbability: trailing_losses should be True or False.')

--- a/surveySimPP/modules/PPDetectionProbability.py
+++ b/surveySimPP/modules/PPDetectionProbability.py
@@ -23,6 +23,8 @@ Calculate probability of detection due to fading
 """
 
 import numpy as np
+import sys
+import logging
 
 __all__ = ['PPDetectionProbability']
 
@@ -89,5 +91,6 @@ def PPDetectionProbability(oif_df, trailing_losses=False, trailing_loss_name='dm
     elif trailing_losses:
         return calcDetectionProbability(oif_df[magnitude_name] + oif_df[trailing_loss_name], oif_df[limiting_magnitude_name], fillFactor, w)
     else:
+        pplogger = logging.getLogger(__name__)
         pplogger.error('ERROR: PPDetectionProbability: trailing_losses should be True or False.')
         sys.exit('ERROR: PPDetectionProbability: trailing_losses should be True or False.')

--- a/surveySimPP/modules/PPDropObservations.py
+++ b/surveySimPP/modules/PPDropObservations.py
@@ -1,7 +1,5 @@
-import numpy as np
-import pandas as pd
+__all__ = ['PPDropObservations']
 
-__all__=['PPDropObservations']
 
 def PPDropObservations(observations, rng, probability="detection probability"):
     """

--- a/surveySimPP/modules/PPFilterFadingFunction.py
+++ b/surveySimPP/modules/PPFilterFadingFunction.py
@@ -1,12 +1,12 @@
 import logging
-import numpy as np
 from .PPDropObservations import PPDropObservations
 from .PPDetectionProbability import PPDetectionProbability
 
+
 def PPFilterFadingFunction(observations, fillfactor, rng):
     """Wrapper function for PPDetectionProbability and PPDropObservations.
-    
-    Calculates detection probability based on a fading function, then drops rows where the 
+
+    Calculates detection probability based on a fading function, then drops rows where the
     probabilty of detection is less than sample drawn from a uniform distribution.
 
     Input
@@ -20,19 +20,19 @@ def PPFilterFadingFunction(observations, fillfactor, rng):
     observations ... new dataframe without observations that could not be observed
 
     """
-    
+
     pplogger = logging.getLogger(__name__)
-    
+
     pplogger.info('Calculating probabilities of detections...')
     observations["detection_probability"] = PPDetectionProbability(observations, fillFactor=fillfactor)
-    
+
     pplogger.info('Number of rows BEFORE applying detection probability threshold: ' + str(len(observations.index)))
 
     pplogger.info('Dropping observations below detection threshold...')
-    observations=PPDropObservations(observations, rng, "detection_probability")
+    observations = PPDropObservations(observations, rng, "detection_probability")
     observations_drop = observations.drop("detection_probability", axis=1)
     observations_drop.reset_index(drop=True, inplace=True)
-    
+
     pplogger.info('Number of rows AFTER applying detection probability threshold: ' + str(len(observations_drop.index)))
-    
+
     return observations_drop

--- a/surveySimPP/modules/PPOutput.py
+++ b/surveySimPP/modules/PPOutput.py
@@ -75,17 +75,26 @@ def PPOutWriteSqlite3(pp_results, outf):
     pp_results.to_sql("pp_results", con=cnx, if_exists="append")
 
 
-def PPWriteOutput(cmd_args, configs, observations, endChunk):
+def PPWriteOutput(cmd_args, configs, observations_in, endChunk):
     """
     Author: Steph Merritt
 
     Description: Writes out the output in the format specified in the config file.
 
-    Mandatory input:	dict, configs, dictionary of config variables created by PPConfigFileParser
+    Mandatory input:    dict, configs, dictionary of config variables created by PPConfigFileParser
                         pandas DataFrame, observations, table of observations for output
     """
 
     pplogger = logging.getLogger(__name__)
+
+    if configs['outputsize'] == 'default':
+        observations = observations_in[['ObjID', 'FieldMJD', 'fieldRA', 'fieldDec', 
+                                        'AstRA(deg)', 'AstDec(deg)', 'AstrometricSigma(deg)', 
+                                        'optFilter', 'observedPSFMag', 'observedTrailedSourceMag', 
+                                        'PhotometricSigma(mag)', 'fiveSigmaDepth', 
+                                        'fiveSigmaDepthAtSource']]
+    #else:
+        #observations = observations_in
 
     pplogger.info('Constructing output path...')
 
@@ -95,7 +104,7 @@ def PPWriteOutput(cmd_args, configs, observations, endChunk):
         pplogger.info('Output to CSV file...')
         observations = PPOutWriteCSV(observations, out)
 
-    elif ((configs['outputformat'] == 'separatelyCSV') or (configs['outputformat'] == 'separatelyCsv') or (configs['outputformat'] == 'separatelycsv')):
+    elif (configs['outputformat'] == 'separatelycsv'):
         outputsuffix = '.csv'
         objid_list = observations['ObjID'].unique().tolist()
         pplogger.info('Output to ' + str(len(objid_list)) + ' separate output CSV files...')
@@ -113,7 +122,7 @@ def PPWriteOutput(cmd_args, configs, observations, endChunk):
         pplogger.info('Output to sqlite3 database...')
         observations = PPOutWriteSqlite3(observations, out)
 
-    elif (configs['outputformat'] == 'hdf5' or configs['outputformat'] == 'HDF5'):
+    elif (configs['outputformat'] == 'hdf5' or configs['outputformat'] == 'h5'):
         outputsuffix = ".h5"
         out = cmd_args['outpath'] + cmd_args['outfilestem'] + outputsuffix
         pplogger.info('Output to HDF5 binary file...')

--- a/surveySimPP/modules/PPRunUtilities.py
+++ b/surveySimPP/modules/PPRunUtilities.py
@@ -250,12 +250,9 @@ def PPConfigFileParser(configfile, survey_name):
     config_dict['trackletInterval'], _ = PPGetValueAndFlag(config, 'FILTERINGPARAMETERS', 'trackletInterval', 'float', 'Tracklet interval not supplied for SSP filtering.')
     config_dict['SSPDetectionEfficiency'], _ = PPGetValueAndFlag(config, 'FILTERINGPARAMETERS', 'SSPDetectionEfficiency', 'float', 'Detection efficiency not supplied for SSP filtering.')
 
-    if (config_dict['inSepThreshold'] is not None
-            and config_dict['minTracklet'] is not None
-            and config_dict['noTracklets'] is not None
-            and config_dict['trackletInterval'] is not None
-            and config_dict['SSPDetectionEfficiency'] is not None):
+    SSPvariables = [config_dict['inSepThreshold'], config_dict['minTracklet'], config_dict['noTracklets'], config_dict['trackletInterval'], config_dict['SSPDetectionEfficiency']]
 
+    if all(SSPvariables):
         # only error handles these values if they are supplied
         if config_dict['minTracklet'] < 1:
             pplogger.error('ERROR: minTracklet is zero or negative.')
@@ -275,11 +272,7 @@ def PPConfigFileParser(configfile, survey_name):
 
         config_dict['SSPLinkingOn'] = True
 
-    elif (config_dict['inSepThreshold'] is None
-            and config_dict['minTracklet'] is None
-            and config_dict['noTracklets'] is None
-            and config_dict['trackletInterval'] is None
-            and config_dict['SSPDetectionEfficiency'] is None):
+    elif not any(SSPvariables):
 
         config_dict['SSPLinkingOn'] = False
 
@@ -287,12 +280,17 @@ def PPConfigFileParser(configfile, survey_name):
         pplogger.error('ERROR: only some SSP linking variables supplied. Supply all five required variables for SSP linking filter, or none to turn filter off.')
         sys.exit('ERROR: only some SSP linking variables supplied. Supply all five required variables for SSP linking filter, or none to turn filter off.')
 
-    # output format
+    # output format and size
 
-    config_dict['outputformat'] = PPGetOrExit(config, 'OUTPUTFORMAT', 'outputformat', 'ERROR: output format not specified.')
-    if config_dict['outputformat'] not in ['csv', 'separatelyCSV', 'separatelyCsv', 'separatelycsv', 'sqlite3', 'hdf5', 'HDF5', 'h5']:
-        pplogger.error('ERROR: output format should be either csv, separatelyCSV, sqlite3 or hdf5.')
-        sys.exit('ERROR: output format should be either csv, separatelyCSV, sqlite3 or hdf5.')
+    config_dict['outputformat'] = PPGetOrExit(config, 'OUTPUTFORMAT', 'outputformat', 'ERROR: output format not specified.').lower()
+    if config_dict['outputformat'] not in ['csv', 'separatelycsv', 'sqlite3', 'hdf5', 'h5']:
+        pplogger.error('ERROR: outputformat should be either csv, separatelyCSV, sqlite3 or hdf5.')
+        sys.exit('ERROR: outputformat should be either csv, separatelyCSV, sqlite3 or hdf5.')
+
+    config_dict['outputsize'] = PPGetOrExit(config, 'OUTPUTFORMAT', 'outputsize', 'ERROR: output size not specified.').lower()
+    if config_dict['outputsize'] not in ['default', 'full']:
+        pplogger.error('ERROR: outputsize should be "default" or "full".')
+        sys.exit('ERROR: outputsize should be "default" or "full".')
 
     # size of chunk
 


### PR DESCRIPTION
Fixes #102.
Output is now cut down to 13 relevant columns. Functionality has been added to change the output based on presets, but currently only one option ('default') is present. Once #220 is fixed, the output will need to be adjusted to include uncertainties for both PSFMag and TrailedSourceMag.

Fixes #164.
Print statement now goes to error log and causes a system exit.

Additional changes:
PEP8 compliance for a few more files. Removed a lot of unnecessary imports.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
