### PR TITLE
Fixing #220 and #211.

### DIFF
--- a/surveySimPP/modules/PPAddUncertainties.py
+++ b/surveySimPP/modules/PPAddUncertainties.py
@@ -105,19 +105,24 @@ class Error(Exception):
 
 #   return (astrSig, photometric_sigma, SNR)
 
-def addUncertainties(detDF, rng):
+def addUncertainties(detDF, configs, rng):
     """
     Generates astrometric and photometric unvertainties, and SNR. Uses uncertainties to randomize the photometry.
     """
 
-    detDF['AstrometricSigma(deg)'], detDF['PhotometricSigma(mag)'], detDF['SNR'] = uncertainties(detDF)
+    detDF['AstrometricSigma(deg)'], detDF['PhotometricSigmaTrailedSource(mag)'], detDF['SNR'] = uncertainties(detDF, filterMagName='TrailedSourceMag')
+    
+    if configs['trailingLossesOn']:
+        _, detDF['PhotometricSigmaPSF(mag)'], detDF['SNR'] = uncertainties(detDF, filterMagName='PSFMag')
+    else:
+        detDF['PhotometricSigmaPSF(mag)'] = detDF['PhotometricSigmaTrailedSource(mag)']
 
     detDF["observedTrailedSourceMag"] = PPRandomizeMeasurements.randomizePhotometry(
                                             detDF, rng, magName="TrailedSourceMag",
-                                            sigName="PhotometricSigma(mag)")
+                                            sigName="PhotometricSigmaTrailedSource(mag)")
     detDF["observedPSFMag"] = PPRandomizeMeasurements.randomizePhotometry(
                                             detDF, rng, magName="PSFMag",
-                                            sigName="PhotometricSigma(mag)")
+                                            sigName="PhotometricSigmaPSF(mag)")
     return detDF
 
 

--- a/surveySimPP/modules/PPOutput.py
+++ b/surveySimPP/modules/PPOutput.py
@@ -91,8 +91,8 @@ def PPWriteOutput(cmd_args, configs, observations_in, endChunk):
         observations = observations_in[['ObjID', 'FieldMJD', 'fieldRA', 'fieldDec', 
                                         'AstRA(deg)', 'AstDec(deg)', 'AstrometricSigma(deg)', 
                                         'optFilter', 'observedPSFMag', 'observedTrailedSourceMag', 
-                                        'PhotometricSigma(mag)', 'fiveSigmaDepth', 
-                                        'fiveSigmaDepthAtSource']]
+                                        'PhotometricSigmaPSF(mag)', 'PhotometricSigmaTrailedSource(mag)', 
+                                        'fiveSigmaDepth', 'fiveSigmaDepthAtSource']]
     #else:
         #observations = observations_in
 

--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -106,7 +106,7 @@ def runLSSTPostProcessing(cmd_args):
         observations['fiveSigmaDepthAtSource'] = PPVignetting.vignettingEffects(observations)
 
         pplogger.info('Calculating astrometric and photometric uncertainties, randomizing photometry...')
-        observations = PPAddUncertainties.addUncertainties(observations, rng)
+        observations = PPAddUncertainties.addUncertainties(observations, configs, rng)
 
         pplogger.info('Applying astrometric uncertainties...')
         observations["AstRATrue(deg)"] = observations["AstRA(deg)"]


### PR DESCRIPTION
Fixes #220.
Uncertainties are now calculated separately for the PSF magnitude and the trailed source magnitude. These are saved as 'PhotometricSigmaPSF(mag)' and 'PhotometricSigmaTrailedSource(mag)' and appear in the output.

Fixes #211.
If trailing losses are turned off, uncertainties are no longer adjusted for trailing loss in _PPAddUncertainties.addUncertainies_ and _PPAddUncertainies.uncertainies_.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
