### PR TITLE
Fixing pip install, updating README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Next, install the pointing database to the ./demo/ folder. This can be found [he
 
 Then the simulator can be run via:
 ```
-surveySimPP -c ./demo/PPConfig.ini -l ./data/demo/colours_10mbas.txt -o ./data/demo/orbits_10mbas.des -p ./data/demo/oif_10mbas.txt -u ./data/out/ -t demorun
+surveySimPP -c ./demo/PPConfig.ini -l ./demo/colours_10mbas.txt -o ./demo/orbits_10mbas.des -p ./demo/oif_10mbas.txt -u ./data/out/ -t demorun
 ```
 
 This will create a .csv file in /data/out/ called demorun.csv with the accompanying log files.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,12 @@ pip install -e .
 
 Then it can be run via:
 ```
-surveySimPP -c ./demo/PPConfig.ini -l ./data/test/testcolour.txt -o ./data/test/testorb.des -p ./data/test/oiftestoutput.txt -u ./data/out -t testrun
+surveySimPP -c ./demo/PPConfig.ini -l ./data/test/testcolour.txt -o ./data/test/testorb.des -p ./data/test/oiftestoutput.txt -u ./data/out/ -t testrun
 ```
+
+This will create a .csv file in /data/out/ called testrun.csv, containing only the column headings.
+
+
 You can also create config files for OIF and the survey simulator by typing:
 ```
 makeConfigOIF

--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ The code can be installed by typing:
 pip install -e .
 ```
 
+Next, install the pointing database to the ./demo/ folder. This can be found [here](http://astro-lsst-01.astro.washington.edu:8080/?runId=1): click one of the links entitled 'baseline_v2.0_10yrs.db' near the top in the SQLite file column.
 
-Then it can be run via:
+
+Then the simulator can be run via:
 ```
-surveySimPP -c ./demo/PPConfig.ini -l ./data/test/testcolour.txt -o ./data/test/testorb.des -p ./data/test/oiftestoutput.txt -u ./data/out/ -t testrun
+surveySimPP -c ./demo/PPConfig.ini -l ./data/demo/colours_10mbas.txt -o ./data/demo/orbits_10mbas.des -p ./data/demo/oif_10mbas.txt -u ./data/out/ -t demorun
 ```
 
-This will create a .csv file in /data/out/ called testrun.csv, containing only the column headings.
+This will create a .csv file in /data/out/ called demorun.csv with the accompanying log files.
 
 
 You can also create config files for OIF and the survey simulator by typing:

--- a/demo/PPConfig.ini
+++ b/demo/PPConfig.ini
@@ -16,7 +16,8 @@
 ephemerides_type=oif
 
 # Location of pointing database.
-pointingdatabase = ./data/test/baseline_10yrs_10klines.db 
+pointingdatabase = ./demo/baseline_v2.0_10yrs.db
+#./data/test/baseline_10yrs_10klines.db 
 #'./data/baseline_v1.3_10yrs.db'# 
 # ./demo/baseline_v2.0_10yrs.db
 
@@ -25,7 +26,7 @@ footprintPath= ./data/detectors_corners.csv
 
 # Database query for extracting data for pointing database.
 # Change this at your peril!
-ppsqldbquery = SELECT observationId, observationStartMJD, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM SummaryAllProps order by observationId
+ppsqldbquery = SELECT observationId, observationStartMJD, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId
 
 # Pointing database format (by separator): csv,whitespace,hdf5
 pointingFormat=whitespace

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent", ],
 
-    install_requires=['numpy', 'pandas==1.3.5', 'scipy', 'astropy', 'sbpy @ git+https://github.com/NASA-Planetary-Science/sbpy.git'],
+    install_requires=['numpy', 'pandas==1.3.5', 'scipy', 'astropy', 'matplotlib', 'sbpy @ git+https://github.com/NASA-Planetary-Science/sbpy.git'],
 
 )


### PR DESCRIPTION
Fixes the pip install by adding matplotlib to setup.py, and also changes README.md so that the test run uses the 10 MBAs demo set and directs the user to install the pointing database in the correct location for that to run.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
