### PR TITLE
Changing setup.py to use latest pip version of sbpy.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ wheel
 setuptools_scm>=3.4
 astropy
 scipy
-sbpy @ git+https://github.com/NASA-Planetary-Science/sbpy.git
+sbpy
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent", ],
 
-    install_requires=['numpy', 'pandas==1.3.5', 'scipy', 'astropy', 'matplotlib', 'sbpy @ git+https://github.com/NASA-Planetary-Science/sbpy.git'],
+    install_requires=['numpy', 'pandas==1.3.5', 'scipy', 'astropy', 'matplotlib', 'sbpy'],
 
 )


### PR DESCRIPTION
The pip-installable version of sbpy is now compatible with the code. Changed setup.py to point to the pip-installable version rather than the development version.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
