### PR TITLE
Fixing #72 and #160.

### DIFF
--- a/demo/PPConfig.ini
+++ b/demo/PPConfig.ini
@@ -39,8 +39,9 @@ auxFormat=whitespace
 
 
 [OBJECTS]
-# Types of objects: asteroid or comet
-objecttype = asteroid
+# Flag for cometary activity. If not none, cometary parameters must be specified at the command line.
+# Options: none, comet. Default: none.
+cometactivity = none
 
 
 [FILTERS]

--- a/surveySimPP/modules/PPRunUtilities.py
+++ b/surveySimPP/modules/PPRunUtilities.py
@@ -172,12 +172,12 @@ def PPConfigFileParser(configfile, survey_name):
     PPFindFileOrExit(config_dict['pointingdatabase'], 'pointingdatabase')
     config_dict['ppdbquery'] = PPGetOrExit(config, 'INPUTFILES', 'ppsqldbquery', 'ERROR: no pointing database SQLite3 query provided.')
 
-    # object type checking
+    # cometary activity checking
 
-    config_dict['objecttype'] = PPGetOrExit(config, 'OBJECTS', 'objecttype', 'ERROR: no object type provided.')
-    if config_dict['objecttype'] not in ['asteroid', 'comet']:
-        pplogger.error('ERROR: objecttype is neither an asteroid or a comet.')
-        sys.exit('ERROR: objecttype is neither an asteroid or a comet.')
+    config_dict['cometactivity'] = PPGetOrExit(config, 'OBJECTS', 'cometactivity', 'ERROR: no comet activity specified.').lower()
+    if config_dict['cometactivity'] not in ['asteroid', 'none']:
+        pplogger.error('ERROR: cometactivity must be "comet" or "none".')
+        sys.exit('ERROR: cometactivity must be "comet" or "none".')
 
     # filters
 
@@ -347,7 +347,10 @@ def PPPrintConfigsToLog(configs):
 
     pplogger = logging.getLogger(__name__)
 
-    pplogger.info('Object type is ' + str(configs['objecttype']))
+    if configs['cometactivity'] == 'comet':
+        pplogger.info('Cometary activity set to: ' + str(configs['cometary activity']))
+    elif configs['cometactivity'] == 'none':
+        pplogger.info('No cometary activity.')
 
     pplogger.info('Pointing simulation result format is: ' + configs['pointingFormat'])
     pplogger.info('Pointing simulation result path is: ' + configs['pointingdatabase'])
@@ -488,7 +491,7 @@ def PPReadAllInput(cmd_args, configs, filterpointing, startChunk, incrStep):
 
     pplogger.info('Reading input physical parameters: ' + cmd_args['paramsinput'])
     padacl = PPReadPhysicalParameters(cmd_args['paramsinput'], startChunk, incrStep, configs['filesep'])
-    if (configs['objecttype'] == 'comet'):
+    if (configs['cometactivity'] == 'comet'):
         pplogger.info('Reading cometary parameters: ' + cmd_args['cometinput'])
         padaco = PPReadCometaryInput(cmd_args['cometinput'], startChunk, incrStep, configs['filesep'])
 
@@ -511,13 +514,13 @@ def PPReadAllInput(cmd_args, configs, filterpointing, startChunk, incrStep):
     pplogger.info('Checking if orbit, brightness, physical parameters and pointing simulation input files match...')
     PPCheckOrbitAndPhysicalParametersMatching(padaor, padacl, padafr)
 
-    if (configs['objecttype'] == 'comet'):
+    if (configs['cometactivity'] == 'comet'):
         PPCheckOrbitAndPhysicalParametersMatching(padaor, padaco, padafr)
 
     pplogger.info('Joining physical parameters and orbital data with simulation data...')
     observations = PPJoinPhysicalParametersPointing(padafr, padacl)
     observations = PPJoinOrbitalData(observations, padaor)
-    if (configs['objecttype'] == 'comet'):
+    if (configs['cometactivity'] == 'comet'):
         pplogger.info('Joining cometary data...')
         observations = PPJoinPhysicalParametersPointing(observations, padaco)
 

--- a/surveySimPP/modules/__init__.py
+++ b/surveySimPP/modules/__init__.py
@@ -26,7 +26,6 @@ from . import PPReadIntermDatabase
 from . import PPReadOif
 from . import PPReadOrbitFile
 from . import PPTrailingLoss
-from . import PPTranslateMagnitude
 from . import PPVignetting
 from . import PPRunUtilities
 from . import PPApplyFOVFilter

--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -91,7 +91,7 @@ def runLSSTPostProcessing(cmd_args):
                                                     mainfilter,
                                                     configs['othercolours'],
                                                     configs['observing_filters'],
-                                                    configs['objecttype'])
+                                                    configs['cometactivity'])
 
         # ----------------------------------------------------------------------
         if configs['trailingLossesOn']:

--- a/utilities/PPTranslateMagnitude.py
+++ b/utilities/PPTranslateMagnitude.py
@@ -1,7 +1,8 @@
 import pandas as pd
 import numpy as np
 
-__all__=['PPTranslateMagnitude']
+__all__ = ['PPTranslateMagnitude']
+
 
 def PPTranslateMagnitude(oif_output, survey_db, colors,
                          oifFieldIDName='FieldID', surveyFieldIDName='observationId',

--- a/utilities/makeConfigPP.py
+++ b/utilities/makeConfigPP.py
@@ -12,7 +12,7 @@ def makeConfigFile(args):
 
     config.read_dict({
             'OBJECTS':
-            {'objecttype': args.objecttype},
+            {'cometactivity': args.cometactivity},
             'INPUTFILES':
             {'ephemerides_type': args.ephemeridestype,
                 'pointingdatabase': args.pointingdatabase,
@@ -61,7 +61,7 @@ def main():
     parser.add_argument('filename', help='Filepath where you want to store the config file.', type=str)
 
     # OBJECTS
-    parser.add_argument('--objecttype', '-obj', help='Type of object: asteroid or comet. Default is "asteroid".', type=str, default='asteroid')
+    parser.add_argument('--cometactivity', '-com', help='Type of cometary activity. Options are "comet" or None. Default is None.', type=str, default=None)
 
     # INPUTFILES
     parser.add_argument('--ephemeridestype', '-eph', help='Type of input ephemerides: default = oif. Options: currently only oif.', type=str, default='oif')


### PR DESCRIPTION
Fixes #72.

The "objecttype" flag in the config file has now been changed to "cometactivity", where "none" triggers the behaviour previously assigned to "asteroid" and "comet" triggers the behaviour previously assigned to "comet". This change has been propagated throughout the code, including to the config file generator.

Fixes #160.
PPTranslateMagnitude is now in utilities. Altered __init__.py.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
