### PR TITLE
Add testcase for ObjectsInField

### DIFF
--- a/demo/README_run_oif_test.sh
+++ b/demo/README_run_oif_test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# 1. Ensure that objectsInField is installed, if not, then
+# follow the instructions at https://github.com/AsteroidSurveySimulator/objectsInField
+# to install objects in field
+
+# Execute the following task
+
+oif -f oif.test.input.config | awk 'NR>24' > oif_10MBAs_test.txt

--- a/demo/oif.test.input.config
+++ b/demo/oif.test.input.config
@@ -1,0 +1,24 @@
+[ASTEROID]
+Population model    = orbits_10mbas.des
+SPK T0              = 59200
+nDays               = 8600
+SPK step            = 1
+nbody               = T
+Input format        =  whitespace
+
+
+[SURVEY]
+Survey database     = baseline_v2.0_10yrs.db
+Field1              = 1
+nFields             = 2084198
+Telescope           = I11
+Surveydbquery       = SELECT observationId,observationStartMJD,fieldRA,fieldDEC,rotSkyPos FROM observations order by observationStartMJD
+
+[OUTPUT]
+Output file          = stdout
+Output format        = whitespace
+
+
+[CAMERA]
+Camera              = instrument_circle.dat
+Threshold           = 5


### PR DESCRIPTION
Added instructions and a config file to be able to produce the ephemerides input file through objectsInField.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [ ] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
