### PR TITLE
Fixing error messages

### DIFF
--- a/surveySimPP/modules/PPRunUtilities.py
+++ b/surveySimPP/modules/PPRunUtilities.py
@@ -166,7 +166,9 @@ def PPConfigFileParser(configfile, survey_name):
     # formatting and input
 
     config_dict['pointingFormat'] = PPGetOrExit(config, 'INPUTFILES', 'pointingFormat', 'ERROR: no pointing simulation format is specified.').lower()
-    # if config_dict['pointingFormat'] not in ['csv', 'whitespace', 'hdf5']:
+    if config_dict['pointingFormat'] not in ['csv', 'whitespace', 'hdf5']:
+        pplogger.error('ERROR: outputformat should be either csv, separatelyCSV, sqlite3 or hdf5.')
+        sys.exit('ERROR: outputformat should be either csv, separatelyCSV, sqlite3 or hdf5.')
     
     config_dict['filesep'] = PPGetOrExit(config, 'INPUTFILES', 'auxFormat', 'ERROR: no auxiliary data format specified.')
     config_dict['ephemerides_type'] = PPGetOrExit(config, 'INPUTFILES', 'ephemerides_type', 'ERROR: no ephemerides type provided.')
@@ -255,6 +257,7 @@ def PPConfigFileParser(configfile, survey_name):
 
     SSPvariables = [config_dict['inSepThreshold'], config_dict['minTracklet'], config_dict['noTracklets'], config_dict['trackletInterval'], config_dict['SSPDetectionEfficiency']]
 
+    # the below if-statement explicitly checks for None so a zero triggers the correct error
     if all(v is not None for v in SSPvariables):
         # only error handles these values if they are supplied
         if config_dict['minTracklet'] < 1:
@@ -291,9 +294,9 @@ def PPConfigFileParser(configfile, survey_name):
         sys.exit('ERROR: outputformat should be either csv, separatelyCSV, sqlite3 or hdf5.')
 
     config_dict['outputsize'] = PPGetOrExit(config, 'OUTPUTFORMAT', 'outputsize', 'ERROR: output size not specified.').lower()
-    if config_dict['outputsize'] not in ['default', 'full']:
-        pplogger.error('ERROR: outputsize should be "default" or "full".')
-        sys.exit('ERROR: outputsize should be "default" or "full".')
+    if config_dict['outputsize'] not in ['default']:
+        pplogger.error('ERROR: outputsize should be "default".')
+        sys.exit('ERROR: outputsize should be "default".')
 
     # size of chunk
 

--- a/surveySimPP/modules/PPRunUtilities.py
+++ b/surveySimPP/modules/PPRunUtilities.py
@@ -165,11 +165,14 @@ def PPConfigFileParser(configfile, survey_name):
 
     # formatting and input
 
-    config_dict['pointingFormat'] = PPGetOrExit(config, 'INPUTFILES', 'pointingFormat', 'ERROR: no pointing simulation format is specified.')
+    config_dict['pointingFormat'] = PPGetOrExit(config, 'INPUTFILES', 'pointingFormat', 'ERROR: no pointing simulation format is specified.').lower()
+    # if config_dict['pointingFormat'] not in ['csv', 'whitespace', 'hdf5']:
+    
     config_dict['filesep'] = PPGetOrExit(config, 'INPUTFILES', 'auxFormat', 'ERROR: no auxiliary data format specified.')
     config_dict['ephemerides_type'] = PPGetOrExit(config, 'INPUTFILES', 'ephemerides_type', 'ERROR: no ephemerides type provided.')
     config_dict['pointingdatabase'] = PPGetOrExit(config, 'INPUTFILES', 'pointingdatabase', 'ERROR: no pointing database provided.')
     PPFindFileOrExit(config_dict['pointingdatabase'], 'pointingdatabase')
+    
     config_dict['ppdbquery'] = PPGetOrExit(config, 'INPUTFILES', 'ppsqldbquery', 'ERROR: no pointing database SQLite3 query provided.')
 
     # cometary activity checking
@@ -252,7 +255,7 @@ def PPConfigFileParser(configfile, survey_name):
 
     SSPvariables = [config_dict['inSepThreshold'], config_dict['minTracklet'], config_dict['noTracklets'], config_dict['trackletInterval'], config_dict['SSPDetectionEfficiency']]
 
-    if all(SSPvariables):
+    if all(v is not None for v in SSPvariables):
         # only error handles these values if they are supplied
         if config_dict['minTracklet'] < 1:
             pplogger.error('ERROR: minTracklet is zero or negative.')


### PR DESCRIPTION
One error message was presenting an incorrect option ("full" should not be an option for outputsize any more) and not error handling properly. Another error message wasn't triggering properly if the value of one of the SSP linking variables in the config file was zero (the error handling was treating a zero as a value not being present at all, because of falsiness. Thanks Python.)

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
