### PR TITLE
Switch from pandas `append` to `concat`

### DIFF
--- a/surveySimPP/modules/PPReadIntermDatabase.py
+++ b/surveySimPP/modules/PPReadIntermDatabase.py
@@ -31,10 +31,11 @@ def PPReadIntermDatabase(intermdb,part_objid_list):
       
      cur=con.cursor()
 
-     padafr=pd.DataFrame(columns=namespd)
+     padafr = []
      for j in part_objid_list_:
           cur.execute("SELECT * from interm WHERE ObjID IN (?);", j)
           padafrtmp=pd.DataFrame(cur.fetchall(), columns=namespd)
-          padafr=padafr.append(padafrtmp)
+          padafr.append(padafrtmp)
+     padafr = pd.concat(padafr)
           
      return padafr


### PR DESCRIPTION
`append` has been deprecated in pandas 1.4.0. This switches to the recommended `concat`. See https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.4.0.html#deprecated-dataframe-append-and-series-append

Similar to #78.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
