### PR TITLE
Use `delim_whitespace` for `read_csv`

### DIFF
--- a/surveySimPP/modules/PPMakeIntermediatePointingDatabase.py
+++ b/surveySimPP/modules/PPMakeIntermediatePointingDatabase.py
@@ -46,7 +46,7 @@ def PPMakeIntermediatePointingDatabase(oif_output,outf,chunkSize):
         else:
              incrStep=lenf-startChunk
 
-        interm=pd.read_csv(oif_output, sep='\s+', skiprows=range(1,startChunk+1), nrows=incrStep, header=0)    
+        interm=pd.read_csv(oif_output, delim_whitespace=True, skiprows=range(1,startChunk+1), nrows=incrStep, header=0)
         interm.to_sql("interm", con=cnx, if_exists="append")
         
         startChunk = startChunk + chunkSize

--- a/surveySimPP/modules/PPReadCometaryInput.py
+++ b/surveySimPP/modules/PPReadCometaryInput.py
@@ -37,7 +37,7 @@ def PPReadCometaryInput(comet_datafile, beginLoc, chunkSize,filesep):
     """
 
     if (filesep=="whitespace"):
-        padafr=pd.read_csv(comet_datafile, sep='\s+', skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)
+        padafr=pd.read_csv(comet_datafile, delim_whitespace=True, skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)
     elif (filesep=="csv" or filesep=="comma"):
         padafr=pd.read_csv(comet_datafile, delimiter=',', skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)    
     

--- a/surveySimPP/modules/PPReadOif.py
+++ b/surveySimPP/modules/PPReadOif.py
@@ -37,7 +37,7 @@ def PPReadOif(oif_output, inputformat):
    pplogger = logging.getLogger(__name__)
 
    if (inputformat=="whitespace"):
-       padafr=pd.read_csv(oif_output, sep='\s+')
+       padafr=pd.read_csv(oif_output, delim_whitespace=True)
    elif (inputformat=="comma") or (inputformat=='csv'):
        padafr=pd.read_csv(oif_output, delimiter=',')   
    elif (inputformat=='h5') or (inputformat=='hdf5') or (inputformat=='HDF5'):

--- a/surveySimPP/modules/PPReadOrbitFile.py
+++ b/surveySimPP/modules/PPReadOrbitFile.py
@@ -34,7 +34,7 @@ def PPReadOrbitFile(orbin, beginLoc, chunkSize, filesep):
    pplogger = logging.getLogger(__name__)
    
    if (filesep=="whitespace"):
-       padafr=pd.read_csv(orbin, sep='\s+', skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)
+       padafr=pd.read_csv(orbin, delim_whitespace=True, skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)
    elif (filesep=="csv" or filesep=="comma"):
        padafr=pd.read_csv(orbin, delimiter=',', skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)    
 

--- a/surveySimPP/modules/PPReadPhysicalParameters.py
+++ b/surveySimPP/modules/PPReadPhysicalParameters.py
@@ -34,7 +34,7 @@ def PPReadPhysicalParameters(clr_datafile, beginLoc, chunkSize, filesep):
     """
 
     if (filesep=="whitespace"):
-        padafr=pd.read_csv(clr_datafile, sep='\s+', skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)
+        padafr=pd.read_csv(clr_datafile, delim_whitespace=True, skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)
     elif (filesep=="comma" or filesep=="csv"):
         padafr=pd.read_csv(clr_datafile, skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)
     


### PR DESCRIPTION
Passing `sep='\s+'` is showing a [`DeprecationWarning: invalid escape sequence \s` in the CI tests](https://github.com/dirac-institute/survey_simulator_post_processing/runs/6861875826?check_suite_focus=true#step:6:39), so changing this to `delim_whitespace=True` will hopefully fix that. 

If this doesn't remove the deprecation warning, maybe [`engine="Python"`](https://stackoverflow.com/questions/19632075/how-to-read-file-with-space-separated-values-in-pandas#comment85762338_19632099) will be needed as well.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
