### PR TITLE
Fixing #65.

### DIFF
--- a/demo/PPConfig.ini
+++ b/demo/PPConfig.ini
@@ -46,9 +46,11 @@ cometactivity = none
 
 [FILTERS]
 
-# Main filter, followed by resolved colours, such as, e.g. 'r'+'g-r'='g'
-# Should be given in the following order: main filter in which H is specified, then 
-# resolved filters in the same order as colours specified in physical parameters file.
+# Observing filters of interest.
+# Should be given in the following order: main filter in which H is calculated, then 
+# resolved filters. These must have colour offsets specified in physical parameters file.
+# E.g.: if observing filters are r,g,i,z, physical parameters file must have H column 
+# calculated in r, then also 'g-r', 'i-r', 'z-r' columns.
 # Should be separated by comma.
 observing_filters= r,g,i,z
 

--- a/surveySimPP/modules/PPFilterSSPLinking.py
+++ b/surveySimPP/modules/PPFilterSSPLinking.py
@@ -24,7 +24,7 @@ def PPFilterSSPLinking(padain, detefficiency, minintracklets, nooftracklets, int
     Generally, to be applied after detection threshold.
 
 
-    Mandatory input:   padain: modified pandas dataframe
+    Mandatory input:  padain: modified pandas dataframe
                       detefficiency: float, fractional percentage of successfully linked detections
                       minintracklets: integer, minimum number of observations
                       nooftracklets: integer, number of tracklets required for linking

--- a/surveySimPP/modules/PPReadPhysicalParameters.py
+++ b/surveySimPP/modules/PPReadPhysicalParameters.py
@@ -1,53 +1,59 @@
 #!/bin/python
 
 import pandas as pd
-import os, sys
-import numpy as np
+import sys
+import logging
 
 # Author: Grigori Fedorets
 
 
-def PPReadPhysicalParameters(clr_datafile, beginLoc, chunkSize, filesep):
-
+def PPReadPhysicalParameters(clr_datafile, othercolours, beginLoc, chunkSize, filesep):
     """
     PPReadPhysicalParameters.py
-    
-    
-    Description: This task reads in the physical parameters file and puts it into a 
+
+
+    Description: This task reads in the physical parameters file and puts it into a
     single pandas dataframe for further use downstream by other tasks.
-    
+
     The format of the colours is:
-    
+
     id   colour1 colour2 etc
-    
-    
+
+
     Mandatory input:      string, clr_datafile, name of colour data file
                           integer, beginLoc, location in file where reading begins
-                          integer, chunkSize, length of chunk to be read in 
+                          integer, chunkSize, length of chunk to be read in
                           string, filesep, separator used in input file, blank or comma
-    
+
     Output:               pandas dataframe
-    
-    
-    
+
+
+
     usage: padafr=PPReadColours(clr_datafile, beginLoc, chunkSize,filesep)
     """
 
-    if (filesep=="whitespace"):
-        padafr=pd.read_csv(clr_datafile, delim_whitespace=True, skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)
-    elif (filesep=="comma" or filesep=="csv"):
-        padafr=pd.read_csv(clr_datafile, skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)
-    
+    pplogger = logging.getLogger(__name__)
+
+    if (filesep == "whitespace"):
+        padafr = pd.read_csv(clr_datafile, delim_whitespace=True, skiprows=range(1, beginLoc + 1), nrows=chunkSize, header=0)
+    elif (filesep == "comma" or filesep == "csv"):
+        padafr=pd.read_csv(clr_datafile, skiprows=range(1, beginLoc + 1), nrows=chunkSize, header=0)
+        
+    # check that the columns match up with the othercolours calculated from observing_filters config variable
+    if not all(colour in padafr.columns for colour in othercolours):
+        pplogger.error('ERROR: colour offset columns in physical parameters file do not match with observing filters specified in config file.')
+        sys.exit('ERROR: colour offset columns in physical parameters file do not match with observing filters specified in config file.')
+        
     # check for nans or nulls
 
     if padafr.isnull().values.any():
-         pdt=padafr[padafr.isna().any(axis=1)]
+         pdt = padafr[padafr.isna().any(axis=1)]
          print(pdt)
-         inds=str(pdt['ObjID'].values)
-         outstr="ERROR: uninitialised values when reading colour file. ObjID: " + str(inds)
+         inds = str(pdt['ObjID'].values)
+         outstr = "ERROR: uninitialised values when reading colour file. ObjID: " + str(inds)
+         pplogger.error(outstr)
          sys.exit(outstr)
-    
-    
+
     padafr['ObjID'] = padafr['ObjID'].astype(str)
 
     return padafr

--- a/surveySimPP/modules/PPResolveMagnitudeInFilter.py
+++ b/surveySimPP/modules/PPResolveMagnitudeInFilter.py
@@ -1,50 +1,47 @@
 #!/usr/bin/python
 
-import pandas as pd
 import numpy as np
 
 # Author: Grigori Fedorets, Meg Schwamb
 
 
-def PPResolveMagnitudeInFilter(padain,mainfilter,othercolours,observing_filters):
+def PPResolveMagnitudeInFilter(padain, mainfilter, othercolours, observing_filters):
     """
     PPResolveMagnitudeInFilter.py
-    
+
     Description: This tasks selects a colour offset relevant to each filter at each given pointing
     and calculates the colour in each given filter. The apparent magnitude has already been
     calculated in the main filter.
-    
-    
+
+
     Mandatory input: string, padain, name of input pandas dataframe
                      string, mainfilter, name of the main filter in which the apparent magnitude has been calculated
                      array of strings, othercolours, names of colour offsets (e.g. r-i)
-                     array of strings, observing_filters, names of resulting colours, main filter is the first one, followed 
-                     in order by resolved colours, such as, e.g. 'r'+'g-r'='g'. They should be given in the following order: 
+                     array of strings, observing_filters, names of resulting colours, main filter is the first one, followed
+                     in order by resolved colours, such as, e.g. 'r'+'g-r'='g'. They should be given in the following order:
                      main filter, resolved filters in the same order as respective other colours.
-    
+
     Output: updated padain
-    
+
     Usage: padaout=PPResolveMagnitudeInFilter(padain,mainfilter,othercolours,observing_filters)
-    
+
     """
-    
-    apparent_mag=np.zeros(len(padain), dtype=float)
-    
-    
+
+    apparent_mag = np.zeros(len(padain), dtype=float)
+
     # for cases where the input filter is the main filter
-    inRelevantFilterList=(padain['optFilter']==mainfilter)
-    inRelevantFilter=padain[inRelevantFilterList]
-    if(len(inRelevantFilter)>0):
-        apparent_mag[inRelevantFilterList]=0.0
-    
+    inRelevantFilterList = (padain['optFilter'] == mainfilter)
+    inRelevantFilter = padain[inRelevantFilterList]
+    if(len(inRelevantFilter) > 0):
+        apparent_mag[inRelevantFilterList] = 0.0
+
     # for all other cases, where the offset is required
     for i in np.arange(len(othercolours)):
-        inRelevantFilterList=(padain['optFilter']==observing_filters[i+1])
-        inRelevantFilter=padain[inRelevantFilterList]
-        if(len(inRelevantFilter)>0):
-               apparent_mag[inRelevantFilterList]=inRelevantFilter[othercolours[i]]
+        inRelevantFilterList = (padain['optFilter'] == observing_filters[i + 1])
+        inRelevantFilter = padain[inRelevantFilterList]
+        if(len(inRelevantFilter) > 0):
+            apparent_mag[inRelevantFilterList] = inRelevantFilter[othercolours[i]]
 
     padain['TrailedSourceMag'] = padain[mainfilter] + apparent_mag
-          
-    return padain 
 
+    return padain

--- a/surveySimPP/modules/PPRunUtilities.py
+++ b/surveySimPP/modules/PPRunUtilities.py
@@ -169,7 +169,7 @@ def PPConfigFileParser(configfile, survey_name):
     if config_dict['ephFormat'] not in ['csv', 'whitespace', 'hdf5']:
         pplogger.error('ERROR: ephFormat should be either csv, whitespace, or hdf5.')
         sys.exit('ERROR: ephFormat should be either either csv, whitespace, or hdf5.')
-    
+
     config_dict['filesep'] = PPGetOrExit(config, 'INPUTFILES', 'auxFormat', 'ERROR: no auxiliary data format specified.').lower()
     if config_dict['filesep'] not in ['comma', 'whitespace']:
         pplogger.error('ERROR: auxFormat should be either comma, csv, or whitespace.')
@@ -190,18 +190,11 @@ def PPConfigFileParser(configfile, survey_name):
 
     # filters
 
-    #othercolours = PPGetOrExit(config, 'FILTERS', 'othercolours', 'ERROR: othercolours config file variable not provided.')
-    #config_dict['othercolours'] = [e.strip() for e in othercolours.split(',')]
-
     obsfilters = PPGetOrExit(config, 'FILTERS', 'observing_filters', 'ERROR: observing_filters config file variable not provided.')
     config_dict['observing_filters'] = [e.strip() for e in obsfilters.split(',')]
 
     config_dict['mainfilter'] = config_dict['observing_filters'][0]
     config_dict['othercolours'] = [x + "-" + config_dict['mainfilter'] for x in config_dict['observing_filters'][1:]]
-
-    if (len(config_dict['othercolours']) != len(config_dict['observing_filters']) - 1):
-        pplogger.error('ERROR: mismatch in input config colours and filters: len(othercolours) != len(observing_filters) - 1')
-        sys.exit('ERROR: mismatch in input config colours and filters: len(othercolours) != len(observing_filters) - 1')
 
     PPCheckFiltersForSurvey(survey_name, config_dict['observing_filters'])
 
@@ -319,8 +312,8 @@ def PPConfigFileParser(configfile, survey_name):
     if config_dict['sizeSerialChunk'] < 1:
         pplogger.error('ERROR: sizeSerialChunk is zero or negative.')
         sys.exit('ERROR: sizeSerialChunk is zero or negative.')
-    
-    if config.has_option('GENERAL', 'rng_seed'):  
+
+    if config.has_option('GENERAL', 'rng_seed'):
         config_dict['rng_seed'] = PPGetIntOrExit(config, 'GENERAL', 'rng_seed', 'ERROR: this error should not trigger.')
     else:
         config_dict['rng_seed'] = None
@@ -518,7 +511,7 @@ def PPReadAllInput(cmd_args, configs, filterpointing, startChunk, incrStep):
     padaor = PPReadOrbitFile(cmd_args['orbinfile'], startChunk, incrStep, configs['filesep'])
 
     pplogger.info('Reading input physical parameters: ' + cmd_args['paramsinput'])
-    padacl = PPReadPhysicalParameters(cmd_args['paramsinput'], startChunk, incrStep, configs['filesep'])
+    padacl = PPReadPhysicalParameters(cmd_args['paramsinput'], configs['othercolours'], startChunk, incrStep, configs['filesep'])
     if (configs['cometactivity'] == 'comet'):
         pplogger.info('Reading cometary parameters: ' + cmd_args['cometinput'])
         padaco = PPReadCometaryInput(cmd_args['cometinput'], startChunk, incrStep, configs['filesep'])

--- a/surveySimPP/modules/tests/test_PPCalculateSimpleCometaryMagnitude.py
+++ b/surveySimPP/modules/tests/test_PPCalculateSimpleCometaryMagnitude.py
@@ -14,7 +14,7 @@ def test_PPCalculateSimpleCometaryMagnitude():
     from surveySimPP.modules.PPCalculateSimpleCometaryMagnitude import PPCalculateSimpleCometaryMagnitude
 
     padafr = PPReadOif(get_test_filepath('67P.out'), 'whitespace')
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcometcolour.txt'), 0, 3, 'whitespace')
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcometcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 3, 'whitespace')
     padaco = PPReadCometaryInput(get_test_filepath('testcomet.txt'), 0, 3, 'whitespace')
     padaor = PPReadOrbitFile(get_test_filepath('67P.orb.des'), 0, 3, 'whitespace')
 

--- a/surveySimPP/modules/tests/test_PPCheckOrbitAndPhysicalParametersMatching.py
+++ b/surveySimPP/modules/tests/test_PPCheckOrbitAndPhysicalParametersMatching.py
@@ -13,7 +13,7 @@ def test_PPCheckOrbitAndPhysicalParametersMatching():
     compval = 1
 
     padaor = PPReadOrbitFile(get_test_filepath('testorb.des'), 0, 10, 'whitespace')
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 10, 'whitespace')
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 10, 'whitespace')
     padapo = PPReadOif(get_test_filepath('oiftestoutput.txt'), 'whitespace')
 
     print(padaor)

--- a/surveySimPP/modules/tests/test_PPJoinOrbitalData.py
+++ b/surveySimPP/modules/tests/test_PPJoinOrbitalData.py
@@ -12,7 +12,7 @@ def test_PPJoinCOrbitalData():
     from surveySimPP.modules.PPReadOrbitFile import PPReadOrbitFile
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), "whitespace")
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, "whitespace")
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, "whitespace")
     padaor = PPReadOrbitFile(get_test_filepath('testorb.des'), 0, 5, "whitespace")
 
     padain = PPJoinPhysicalParametersPointing(padafr, padacl)

--- a/surveySimPP/modules/tests/test_PPJoinPhysicalParametersPointing.py
+++ b/surveySimPP/modules/tests/test_PPJoinPhysicalParametersPointing.py
@@ -1,8 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -13,7 +10,7 @@ def test_PPJoinPhysicalParametersPointing():
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), 'whitespace')
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, 'whitespace')
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, 'whitespace')
 
     padare = PPJoinPhysicalParametersPointing(padafr, padacl)
 

--- a/surveySimPP/modules/tests/test_PPMatchPointingsAndColours.py
+++ b/surveySimPP/modules/tests/test_PPMatchPointingsAndColours.py
@@ -1,8 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -12,10 +9,10 @@ def test_PPMatchPointingsAndColours():
     from surveySimPP.modules.PPReadOif import PPReadOif
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
     from surveySimPP.modules.PPMatchPointing import PPMatchPointing
-    from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
+    # from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), 'whitespace')
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, 'whitespace')
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, 'whitespace')
 
     resdf = PPJoinPhysicalParametersPointing(padafr, padacl)
 

--- a/surveySimPP/modules/tests/test_PPOutWriteCSV.py
+++ b/surveySimPP/modules/tests/test_PPOutWriteCSV.py
@@ -1,10 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-import os
-import sys
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -14,11 +9,11 @@ def test_PPOutWriteCSV():
     from surveySimPP.modules.PPReadOif import PPReadOif
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
     from surveySimPP.modules.PPMatchPointing import PPMatchPointing
-    from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
-    from surveySimPP.modules.PPOutput import PPOutWriteCSV
+    # from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
+    # from surveySimPP.modules.PPOutput import PPOutWriteCSV
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), "whitespace")
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, "whitespace")
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, "whitespace")
 
     resdf = PPJoinPhysicalParametersPointing(padafr, padacl)
 

--- a/surveySimPP/modules/tests/test_PPOutWriteHDF5.py
+++ b/surveySimPP/modules/tests/test_PPOutWriteHDF5.py
@@ -1,10 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-import os
-import sys
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -14,11 +9,11 @@ def test_PPOutWriteHDF5():
     from surveySimPP.modules.PPReadOif import PPReadOif
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
     from surveySimPP.modules.PPMatchPointing import PPMatchPointing
-    from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
-    from surveySimPP.modules.PPOutput import PPOutWriteHDF5
+    # from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
+    # from surveySimPP.modules.PPOutput import PPOutWriteHDF5
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), "whitespace")
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 20, "whitespace")
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 20, "whitespace")
 
     resdf = PPJoinPhysicalParametersPointing(padafr, padacl)
 

--- a/surveySimPP/modules/tests/test_PPOutWriteSqlite3.py
+++ b/surveySimPP/modules/tests/test_PPOutWriteSqlite3.py
@@ -1,10 +1,6 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-import os
-import sys
-import sqlite3
+# import sqlite3
 
 from surveySimPP.tests.data import get_test_filepath
 
@@ -15,11 +11,11 @@ def test_PPOutWriteSqlite3():
     from surveySimPP.modules.PPReadOif import PPReadOif
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
     from surveySimPP.modules.PPMatchPointing import PPMatchPointing
-    from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
+    # from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
     from surveySimPP.modules.PPOutput import PPOutWriteSqlite3
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), "whitespace")
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, "whitespace")
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, "whitespace")
 
     resdf = PPJoinPhysicalParametersPointing(padafr, padacl)
 

--- a/surveySimPP/modules/tests/test_PPReadIntermDatabase.py
+++ b/surveySimPP/modules/tests/test_PPReadIntermDatabase.py
@@ -1,9 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-import sqlite3
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -12,7 +8,8 @@ def test_PPReadIntermDatabase(tmp_path):
     from surveySimPP.modules.PPMakeIntermediatePointingDatabase import PPMakeIntermediatePointingDatabase
     from surveySimPP.modules.PPReadIntermDatabase import PPReadIntermDatabase
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, 'whitespace')
+    
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, 'whitespace')
     print(padacl)
     objid_list = padacl['ObjID'].unique().tolist()
 

--- a/surveySimPP/modules/tests/test_PPreadPhysicalParameters.py
+++ b/surveySimPP/modules/tests/test_PPreadPhysicalParameters.py
@@ -1,8 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -10,7 +7,7 @@ def test_PPReadPhysicalParameters():
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
     rescol = 0.3
 
-    padafr = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 3, "whitespace")
+    padafr = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 3, "whitespace")
     val = padafr.at[0, 'g-r']
 
     assert rescol == val


### PR DESCRIPTION
Fixes #65.

PPReadPhysicalParameters now checks to make sure that the physical parameters file contains the colour offset columns which match the observing filters specified in the config file. If it doesn't, it errors out gracefully. Also changed many unit tests to reflect the fact that PPReadPhysicalParameters now takes 'othercolours' as an argument. All files I worked on are now PEP8 compliant.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
