### PR TITLE
Fixing #65, adding verbose flag.

### DIFF
--- a/demo/PPConfig.ini
+++ b/demo/PPConfig.ini
@@ -46,9 +46,11 @@ cometactivity = none
 
 [FILTERS]
 
-# Main filter, followed by resolved colours, such as, e.g. 'r'+'g-r'='g'
-# Should be given in the following order: main filter in which H is specified, then 
-# resolved filters in the same order as colours specified in physical parameters file.
+# Observing filters of interest.
+# Should be given in the following order: main filter in which H is calculated, then 
+# resolved filters. These must have colour offsets specified in physical parameters file.
+# E.g.: if observing filters are r,g,i,z, physical parameters file must have H column 
+# calculated in r, then also 'g-r', 'i-r', 'z-r' columns.
 # Should be separated by comma.
 observing_filters= r,g,i,z
 

--- a/surveySimPP/modules/PPApplyFOVFilter.py
+++ b/surveySimPP/modules/PPApplyFOVFilter.py
@@ -5,7 +5,7 @@ import logging
 import numpy as np
 
 
-def PPApplyFOVFilter(observations, configs, rng):
+def PPApplyFOVFilter(observations, configs, rng, verbose=False):
     """
     PPApplyFootprint.py
 
@@ -24,14 +24,15 @@ def PPApplyFOVFilter(observations, configs, rng):
     """
 
     pplogger = logging.getLogger(__name__)
+    verboselog = pplogger.info if verbose else lambda *a, **k: None
 
     if configs['cameraModel'] == 'circle' and not configs['fadingFunctionOn']:
-        pplogger.info('FOV is circular and fading function is off. Removing random observations.')
+        verboselog('FOV is circular and fading function is off. Removing random observations.')
 
         observations = PPSimpleSensorArea(observations, rng, configs['fillfactor'])
 
     elif configs['cameraModel'] == 'footprint':
-        pplogger.info('Applying sensor footprint filter...')
+        verboselog('Applying sensor footprint filter...')
         footprintf = PPFootprintFilter.Footprint(configs['footprintPath'])
         onSensor, detectorIDs = footprintf.applyFootprint(observations)
 
@@ -41,7 +42,7 @@ def PPApplyFOVFilter(observations, configs, rng):
         observations = observations.sort_index()
 
     else:
-        pplogger.info('FOV is circular and fading function is on. Skipping FOV filter.')
+        verboselog('FOV is circular and fading function is on. Skipping FOV filter.')
 
     return observations
 

--- a/surveySimPP/modules/PPCalculateApparentMagnitude.py
+++ b/surveySimPP/modules/PPCalculateApparentMagnitude.py
@@ -7,7 +7,7 @@ import logging
 # Author: Grigori Fedorets
 
 
-def PPCalculateApparentMagnitude(observations, phasefunction, mainfilter, othercolours, observing_filters, object_type):
+def PPCalculateApparentMagnitude(observations, phasefunction, mainfilter, othercolours, observing_filters, object_type, verbose=False):
 
     """
     PPCalculateApparentMagnitude(observations, phasefunction, mainfilter, othercolours, observing_filters)
@@ -27,15 +27,15 @@ def PPCalculateApparentMagnitude(observations, phasefunction, mainfilter, otherc
     """
 
     pplogger = logging.getLogger(__name__)
+    verboselog = pplogger.info if verbose else lambda *a, **k: None
 
-    pplogger.info('Calculating apparent magnitudes...')
     observations = PPCalculateApparentMagnitudeInFilter.PPCalculateApparentMagnitudeInFilter(observations, phasefunction, mainfilter)
 
     if (object_type == 'comet'):
-        pplogger.info('Calculating cometary magnitude using a simple model...')
+        verboselog('Calculating cometary magnitude using a simple model...')
         observations = PPCalculateSimpleCometaryMagnitude.PPCalculateSimpleCometaryMagnitude(observations, mainfilter)
 
-    pplogger.info('Selecting and applying correct colour offset...')
+    verboselog('Selecting and applying correct colour offset...')
     observations = PPResolveMagnitudeInFilter.PPResolveMagnitudeInFilter(observations, mainfilter, othercolours, observing_filters)
 
     observations_drop = observations.drop(mainfilter, axis=1)

--- a/surveySimPP/modules/PPCheckOrbitAndPhysicalParametersMatching.py
+++ b/surveySimPP/modules/PPCheckOrbitAndPhysicalParametersMatching.py
@@ -27,6 +27,8 @@ def PPCheckOrbitAndPhysicalParametersMatching(orbin, colin, poiin):
     Usage: PPCheckOrbitAndPhysicalParametersMatching(orbin,colin,poiin)
 
     """
+    
+    pplogger = logging.getLogger(__name__)
 
     poi = pd.unique(poiin['ObjID'])
     poiobjs = pd.Series(poi, dtype=object)
@@ -38,8 +40,8 @@ def PPCheckOrbitAndPhysicalParametersMatching(orbin, colin, poiin):
         if poiobjs.isin(orbin['ObjID']).all():
             return
         else:
-            logging.error('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input pointing and orbit files do not match.')
+            pplogger.error('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input pointing and orbit files do not match.')
             sys.exit('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input pointing and orbit files do not match.')
     else:
-        logging.error('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input physical parameter and orbit files do not match.')
+        pplogger.error('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input physical parameter and orbit files do not match.')
         sys.exit('ERROR: PPCheckOrbitAndPhysicalParametersMatching: input physical parameter and orbit files do not match.')

--- a/surveySimPP/modules/PPFilterFadingFunction.py
+++ b/surveySimPP/modules/PPFilterFadingFunction.py
@@ -3,7 +3,7 @@ from .PPDropObservations import PPDropObservations
 from .PPDetectionProbability import PPDetectionProbability
 
 
-def PPFilterFadingFunction(observations, fillfactor, rng):
+def PPFilterFadingFunction(observations, fillfactor, rng, verbose=False):
     """Wrapper function for PPDetectionProbability and PPDropObservations.
 
     Calculates detection probability based on a fading function, then drops rows where the
@@ -22,17 +22,18 @@ def PPFilterFadingFunction(observations, fillfactor, rng):
     """
 
     pplogger = logging.getLogger(__name__)
+    verboselog = pplogger.info if verbose else lambda *a, **k: None
 
-    pplogger.info('Calculating probabilities of detections...')
+    verboselog('Calculating probabilities of detections...')
     observations["detection_probability"] = PPDetectionProbability(observations, fillFactor=fillfactor)
 
-    pplogger.info('Number of rows BEFORE applying detection probability threshold: ' + str(len(observations.index)))
+    verboselog('Number of rows BEFORE applying detection probability threshold: ' + str(len(observations.index)))
 
-    pplogger.info('Dropping observations below detection threshold...')
+    verboselog('Dropping observations below detection threshold...')
     observations = PPDropObservations(observations, rng, "detection_probability")
     observations_drop = observations.drop("detection_probability", axis=1)
     observations_drop.reset_index(drop=True, inplace=True)
 
-    pplogger.info('Number of rows AFTER applying detection probability threshold: ' + str(len(observations_drop.index)))
+    verboselog('Number of rows AFTER applying detection probability threshold: ' + str(len(observations_drop.index)))
 
     return observations_drop

--- a/surveySimPP/modules/PPFilterSSPLinking.py
+++ b/surveySimPP/modules/PPFilterSSPLinking.py
@@ -24,7 +24,7 @@ def PPFilterSSPLinking(padain, detefficiency, minintracklets, nooftracklets, int
     Generally, to be applied after detection threshold.
 
 
-    Mandatory input:   padain: modified pandas dataframe
+    Mandatory input:  padain: modified pandas dataframe
                       detefficiency: float, fractional percentage of successfully linked detections
                       minintracklets: integer, minimum number of observations
                       nooftracklets: integer, number of tracklets required for linking

--- a/surveySimPP/modules/PPOutput.py
+++ b/surveySimPP/modules/PPOutput.py
@@ -75,7 +75,7 @@ def PPOutWriteSqlite3(pp_results, outf):
     pp_results.to_sql("pp_results", con=cnx, if_exists="append")
 
 
-def PPWriteOutput(cmd_args, configs, observations_in, endChunk):
+def PPWriteOutput(cmd_args, configs, observations_in, endChunk, verbose=False):
     """
     Author: Steph Merritt
 
@@ -86,6 +86,7 @@ def PPWriteOutput(cmd_args, configs, observations_in, endChunk):
     """
 
     pplogger = logging.getLogger(__name__)
+    verboselog = pplogger.info if verbose else lambda *a, **k: None
 
     if configs['outputsize'] == 'default':
         observations = observations_in[['ObjID', 'FieldMJD', 'fieldRA', 'fieldDec', 
@@ -96,18 +97,18 @@ def PPWriteOutput(cmd_args, configs, observations_in, endChunk):
     #else:
         #observations = observations_in
 
-    pplogger.info('Constructing output path...')
+    verboselog('Constructing output path...')
 
     if (configs['outputformat'] == 'csv'):
         outputsuffix = '.csv'
         out = cmd_args['outpath'] + cmd_args['outfilestem'] + outputsuffix
-        pplogger.info('Output to CSV file...')
+        verboselog('Output to CSV file...')
         observations = PPOutWriteCSV(observations, out)
 
     elif (configs['outputformat'] == 'separatelycsv'):
         outputsuffix = '.csv'
         objid_list = observations['ObjID'].unique().tolist()
-        pplogger.info('Output to ' + str(len(objid_list)) + ' separate output CSV files...')
+        verboselog('Output to ' + str(len(objid_list)) + ' separate output CSV files...')
 
         i = 0
         while(i < len(objid_list)):
@@ -119,11 +120,11 @@ def PPWriteOutput(cmd_args, configs, observations_in, endChunk):
     elif (configs['outputformat'] == 'sqlite3'):
         outputsuffix = '.db'
         out = cmd_args['outpath'] + cmd_args['outfilestem'] + outputsuffix
-        pplogger.info('Output to sqlite3 database...')
+        verboselog('Output to sqlite3 database...')
         observations = PPOutWriteSqlite3(observations, out)
 
     elif (configs['outputformat'] == 'hdf5' or configs['outputformat'] == 'h5'):
         outputsuffix = ".h5"
         out = cmd_args['outpath'] + cmd_args['outfilestem'] + outputsuffix
-        pplogger.info('Output to HDF5 binary file...')
+        verboselog('Output to HDF5 binary file...')
         observations = PPOutWriteHDF5(observations, out, str(endChunk))

--- a/surveySimPP/modules/PPReadCometaryInput.py
+++ b/surveySimPP/modules/PPReadCometaryInput.py
@@ -2,6 +2,7 @@
 
 import pandas as pd
 import sys
+import logging
 
 # Author: Grigori Fedorets
 
@@ -32,6 +33,8 @@ def PPReadCometaryInput(comet_datafile, beginLoc, chunkSize, filesep):
 
     usage: padafr=PPReadCometaryInput(comet_datafile, beginLoc, chunkSize)
     """
+    
+    pplogger = logging.getLogger(__name__)
 
     if (filesep == "whitespace"):
         padafr = pd.read_csv(comet_datafile, delim_whitespace=True, skiprows=range(1, beginLoc + 1), nrows=chunkSize, header=0)
@@ -46,6 +49,7 @@ def PPReadCometaryInput(comet_datafile, beginLoc, chunkSize, filesep):
         pdt = padafr[padafr.isna().any(axis=1)]
         inds = str(pdt['ObjID'].values)
         outstr = "ERROR: uninitialised values when reading comet data file. ObjID: " + str(inds)
+        pplogger.error(outstr)
         sys.exit(outstr)
 
     padafr['ObjID'] = padafr['ObjID'].astype(str)

--- a/surveySimPP/modules/PPReadPhysicalParameters.py
+++ b/surveySimPP/modules/PPReadPhysicalParameters.py
@@ -1,53 +1,59 @@
 #!/bin/python
 
 import pandas as pd
-import os, sys
-import numpy as np
+import sys
+import logging
 
 # Author: Grigori Fedorets
 
 
-def PPReadPhysicalParameters(clr_datafile, beginLoc, chunkSize, filesep):
-
+def PPReadPhysicalParameters(clr_datafile, othercolours, beginLoc, chunkSize, filesep):
     """
     PPReadPhysicalParameters.py
-    
-    
-    Description: This task reads in the physical parameters file and puts it into a 
+
+
+    Description: This task reads in the physical parameters file and puts it into a
     single pandas dataframe for further use downstream by other tasks.
-    
+
     The format of the colours is:
-    
+
     id   colour1 colour2 etc
-    
-    
+
+
     Mandatory input:      string, clr_datafile, name of colour data file
                           integer, beginLoc, location in file where reading begins
-                          integer, chunkSize, length of chunk to be read in 
+                          integer, chunkSize, length of chunk to be read in
                           string, filesep, separator used in input file, blank or comma
-    
+
     Output:               pandas dataframe
-    
-    
-    
+
+
+
     usage: padafr=PPReadColours(clr_datafile, beginLoc, chunkSize,filesep)
     """
 
-    if (filesep=="whitespace"):
-        padafr=pd.read_csv(clr_datafile, delim_whitespace=True, skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)
-    elif (filesep=="comma" or filesep=="csv"):
-        padafr=pd.read_csv(clr_datafile, skiprows=range(1,beginLoc+1), nrows=chunkSize, header=0)
-    
+    pplogger = logging.getLogger(__name__)
+
+    if (filesep == "whitespace"):
+        padafr = pd.read_csv(clr_datafile, delim_whitespace=True, skiprows=range(1, beginLoc + 1), nrows=chunkSize, header=0)
+    elif (filesep == "comma" or filesep == "csv"):
+        padafr=pd.read_csv(clr_datafile, skiprows=range(1, beginLoc + 1), nrows=chunkSize, header=0)
+        
+    # check that the columns match up with the othercolours calculated from observing_filters config variable
+    if not all(colour in padafr.columns for colour in othercolours):
+        pplogger.error('ERROR: colour offset columns in physical parameters file do not match with observing filters specified in config file.')
+        sys.exit('ERROR: colour offset columns in physical parameters file do not match with observing filters specified in config file.')
+        
     # check for nans or nulls
 
     if padafr.isnull().values.any():
-         pdt=padafr[padafr.isna().any(axis=1)]
+         pdt = padafr[padafr.isna().any(axis=1)]
          print(pdt)
-         inds=str(pdt['ObjID'].values)
-         outstr="ERROR: uninitialised values when reading colour file. ObjID: " + str(inds)
+         inds = str(pdt['ObjID'].values)
+         outstr = "ERROR: uninitialised values when reading colour file. ObjID: " + str(inds)
+         pplogger.error(outstr)
          sys.exit(outstr)
-    
-    
+
     padafr['ObjID'] = padafr['ObjID'].astype(str)
 
     return padafr

--- a/surveySimPP/modules/PPResolveMagnitudeInFilter.py
+++ b/surveySimPP/modules/PPResolveMagnitudeInFilter.py
@@ -1,50 +1,47 @@
 #!/usr/bin/python
 
-import pandas as pd
 import numpy as np
 
 # Author: Grigori Fedorets, Meg Schwamb
 
 
-def PPResolveMagnitudeInFilter(padain,mainfilter,othercolours,observing_filters):
+def PPResolveMagnitudeInFilter(padain, mainfilter, othercolours, observing_filters):
     """
     PPResolveMagnitudeInFilter.py
-    
+
     Description: This tasks selects a colour offset relevant to each filter at each given pointing
     and calculates the colour in each given filter. The apparent magnitude has already been
     calculated in the main filter.
-    
-    
+
+
     Mandatory input: string, padain, name of input pandas dataframe
                      string, mainfilter, name of the main filter in which the apparent magnitude has been calculated
                      array of strings, othercolours, names of colour offsets (e.g. r-i)
-                     array of strings, observing_filters, names of resulting colours, main filter is the first one, followed 
-                     in order by resolved colours, such as, e.g. 'r'+'g-r'='g'. They should be given in the following order: 
+                     array of strings, observing_filters, names of resulting colours, main filter is the first one, followed
+                     in order by resolved colours, such as, e.g. 'r'+'g-r'='g'. They should be given in the following order:
                      main filter, resolved filters in the same order as respective other colours.
-    
+
     Output: updated padain
-    
+
     Usage: padaout=PPResolveMagnitudeInFilter(padain,mainfilter,othercolours,observing_filters)
-    
+
     """
-    
-    apparent_mag=np.zeros(len(padain), dtype=float)
-    
-    
+
+    apparent_mag = np.zeros(len(padain), dtype=float)
+
     # for cases where the input filter is the main filter
-    inRelevantFilterList=(padain['optFilter']==mainfilter)
-    inRelevantFilter=padain[inRelevantFilterList]
-    if(len(inRelevantFilter)>0):
-        apparent_mag[inRelevantFilterList]=0.0
-    
+    inRelevantFilterList = (padain['optFilter'] == mainfilter)
+    inRelevantFilter = padain[inRelevantFilterList]
+    if(len(inRelevantFilter) > 0):
+        apparent_mag[inRelevantFilterList] = 0.0
+
     # for all other cases, where the offset is required
     for i in np.arange(len(othercolours)):
-        inRelevantFilterList=(padain['optFilter']==observing_filters[i+1])
-        inRelevantFilter=padain[inRelevantFilterList]
-        if(len(inRelevantFilter)>0):
-               apparent_mag[inRelevantFilterList]=inRelevantFilter[othercolours[i]]
+        inRelevantFilterList = (padain['optFilter'] == observing_filters[i + 1])
+        inRelevantFilter = padain[inRelevantFilterList]
+        if(len(inRelevantFilter) > 0):
+            apparent_mag[inRelevantFilterList] = inRelevantFilter[othercolours[i]]
 
     padain['TrailedSourceMag'] = padain[mainfilter] + apparent_mag
-          
-    return padain 
 
+    return padain

--- a/surveySimPP/modules/PPRunUtilities.py
+++ b/surveySimPP/modules/PPRunUtilities.py
@@ -169,7 +169,7 @@ def PPConfigFileParser(configfile, survey_name):
     if config_dict['ephFormat'] not in ['csv', 'whitespace', 'hdf5']:
         pplogger.error('ERROR: ephFormat should be either csv, whitespace, or hdf5.')
         sys.exit('ERROR: ephFormat should be either either csv, whitespace, or hdf5.')
-    
+
     config_dict['filesep'] = PPGetOrExit(config, 'INPUTFILES', 'auxFormat', 'ERROR: no auxiliary data format specified.').lower()
     if config_dict['filesep'] not in ['comma', 'whitespace']:
         pplogger.error('ERROR: auxFormat should be either comma, csv, or whitespace.')
@@ -190,18 +190,11 @@ def PPConfigFileParser(configfile, survey_name):
 
     # filters
 
-    #othercolours = PPGetOrExit(config, 'FILTERS', 'othercolours', 'ERROR: othercolours config file variable not provided.')
-    #config_dict['othercolours'] = [e.strip() for e in othercolours.split(',')]
-
     obsfilters = PPGetOrExit(config, 'FILTERS', 'observing_filters', 'ERROR: observing_filters config file variable not provided.')
     config_dict['observing_filters'] = [e.strip() for e in obsfilters.split(',')]
 
     config_dict['mainfilter'] = config_dict['observing_filters'][0]
     config_dict['othercolours'] = [x + "-" + config_dict['mainfilter'] for x in config_dict['observing_filters'][1:]]
-
-    if (len(config_dict['othercolours']) != len(config_dict['observing_filters']) - 1):
-        pplogger.error('ERROR: mismatch in input config colours and filters: len(othercolours) != len(observing_filters) - 1')
-        sys.exit('ERROR: mismatch in input config colours and filters: len(othercolours) != len(observing_filters) - 1')
 
     PPCheckFiltersForSurvey(survey_name, config_dict['observing_filters'])
 
@@ -319,8 +312,8 @@ def PPConfigFileParser(configfile, survey_name):
     if config_dict['sizeSerialChunk'] < 1:
         pplogger.error('ERROR: sizeSerialChunk is zero or negative.')
         sys.exit('ERROR: sizeSerialChunk is zero or negative.')
-    
-    if config.has_option('GENERAL', 'rng_seed'):  
+
+    if config.has_option('GENERAL', 'rng_seed'):
         config_dict['rng_seed'] = PPGetIntOrExit(config, 'GENERAL', 'rng_seed', 'ERROR: this error should not trigger.')
     else:
         config_dict['rng_seed'] = None
@@ -518,7 +511,7 @@ def PPReadAllInput(cmd_args, configs, filterpointing, startChunk, incrStep):
     padaor = PPReadOrbitFile(cmd_args['orbinfile'], startChunk, incrStep, configs['filesep'])
 
     pplogger.info('Reading input physical parameters: ' + cmd_args['paramsinput'])
-    padacl = PPReadPhysicalParameters(cmd_args['paramsinput'], startChunk, incrStep, configs['filesep'])
+    padacl = PPReadPhysicalParameters(cmd_args['paramsinput'], configs['othercolours'], startChunk, incrStep, configs['filesep'])
     if (configs['cometactivity'] == 'comet'):
         pplogger.info('Reading cometary parameters: ' + cmd_args['cometinput'])
         padaco = PPReadCometaryInput(cmd_args['cometinput'], startChunk, incrStep, configs['filesep'])

--- a/surveySimPP/modules/tests/test_PPCalculateSimpleCometaryMagnitude.py
+++ b/surveySimPP/modules/tests/test_PPCalculateSimpleCometaryMagnitude.py
@@ -14,7 +14,7 @@ def test_PPCalculateSimpleCometaryMagnitude():
     from surveySimPP.modules.PPCalculateSimpleCometaryMagnitude import PPCalculateSimpleCometaryMagnitude
 
     padafr = PPReadOif(get_test_filepath('67P.out'), 'whitespace')
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcometcolour.txt'), 0, 3, 'whitespace')
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcometcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 3, 'whitespace')
     padaco = PPReadCometaryInput(get_test_filepath('testcomet.txt'), 0, 3, 'whitespace')
     padaor = PPReadOrbitFile(get_test_filepath('67P.orb.des'), 0, 3, 'whitespace')
 

--- a/surveySimPP/modules/tests/test_PPCheckOrbitAndPhysicalParametersMatching.py
+++ b/surveySimPP/modules/tests/test_PPCheckOrbitAndPhysicalParametersMatching.py
@@ -13,7 +13,7 @@ def test_PPCheckOrbitAndPhysicalParametersMatching():
     compval = 1
 
     padaor = PPReadOrbitFile(get_test_filepath('testorb.des'), 0, 10, 'whitespace')
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 10, 'whitespace')
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 10, 'whitespace')
     padapo = PPReadOif(get_test_filepath('oiftestoutput.txt'), 'whitespace')
 
     print(padaor)

--- a/surveySimPP/modules/tests/test_PPJoinOrbitalData.py
+++ b/surveySimPP/modules/tests/test_PPJoinOrbitalData.py
@@ -12,7 +12,7 @@ def test_PPJoinCOrbitalData():
     from surveySimPP.modules.PPReadOrbitFile import PPReadOrbitFile
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), "whitespace")
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, "whitespace")
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, "whitespace")
     padaor = PPReadOrbitFile(get_test_filepath('testorb.des'), 0, 5, "whitespace")
 
     padain = PPJoinPhysicalParametersPointing(padafr, padacl)

--- a/surveySimPP/modules/tests/test_PPJoinPhysicalParametersPointing.py
+++ b/surveySimPP/modules/tests/test_PPJoinPhysicalParametersPointing.py
@@ -1,8 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -13,7 +10,7 @@ def test_PPJoinPhysicalParametersPointing():
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), 'whitespace')
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, 'whitespace')
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, 'whitespace')
 
     padare = PPJoinPhysicalParametersPointing(padafr, padacl)
 

--- a/surveySimPP/modules/tests/test_PPMatchPointingsAndColours.py
+++ b/surveySimPP/modules/tests/test_PPMatchPointingsAndColours.py
@@ -1,8 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -12,10 +9,10 @@ def test_PPMatchPointingsAndColours():
     from surveySimPP.modules.PPReadOif import PPReadOif
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
     from surveySimPP.modules.PPMatchPointing import PPMatchPointing
-    from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
+    # from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), 'whitespace')
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, 'whitespace')
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, 'whitespace')
 
     resdf = PPJoinPhysicalParametersPointing(padafr, padacl)
 

--- a/surveySimPP/modules/tests/test_PPOutWriteCSV.py
+++ b/surveySimPP/modules/tests/test_PPOutWriteCSV.py
@@ -1,10 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-import os
-import sys
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -14,11 +9,11 @@ def test_PPOutWriteCSV():
     from surveySimPP.modules.PPReadOif import PPReadOif
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
     from surveySimPP.modules.PPMatchPointing import PPMatchPointing
-    from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
-    from surveySimPP.modules.PPOutput import PPOutWriteCSV
+    # from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
+    # from surveySimPP.modules.PPOutput import PPOutWriteCSV
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), "whitespace")
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, "whitespace")
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, "whitespace")
 
     resdf = PPJoinPhysicalParametersPointing(padafr, padacl)
 

--- a/surveySimPP/modules/tests/test_PPOutWriteHDF5.py
+++ b/surveySimPP/modules/tests/test_PPOutWriteHDF5.py
@@ -1,10 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-import os
-import sys
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -14,11 +9,11 @@ def test_PPOutWriteHDF5():
     from surveySimPP.modules.PPReadOif import PPReadOif
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
     from surveySimPP.modules.PPMatchPointing import PPMatchPointing
-    from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
-    from surveySimPP.modules.PPOutput import PPOutWriteHDF5
+    # from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
+    # from surveySimPP.modules.PPOutput import PPOutWriteHDF5
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), "whitespace")
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 20, "whitespace")
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 20, "whitespace")
 
     resdf = PPJoinPhysicalParametersPointing(padafr, padacl)
 

--- a/surveySimPP/modules/tests/test_PPOutWriteSqlite3.py
+++ b/surveySimPP/modules/tests/test_PPOutWriteSqlite3.py
@@ -1,10 +1,6 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-import os
-import sys
-import sqlite3
+# import sqlite3
 
 from surveySimPP.tests.data import get_test_filepath
 
@@ -15,11 +11,11 @@ def test_PPOutWriteSqlite3():
     from surveySimPP.modules.PPReadOif import PPReadOif
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
     from surveySimPP.modules.PPMatchPointing import PPMatchPointing
-    from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
+    # from surveySimPP.modules.PPMatchPointingsAndColours import PPMatchPointingsAndColours
     from surveySimPP.modules.PPOutput import PPOutWriteSqlite3
 
     padafr = PPReadOif(get_test_filepath('oiftestoutput.txt'), "whitespace")
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, "whitespace")
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, "whitespace")
 
     resdf = PPJoinPhysicalParametersPointing(padafr, padacl)
 

--- a/surveySimPP/modules/tests/test_PPReadIntermDatabase.py
+++ b/surveySimPP/modules/tests/test_PPReadIntermDatabase.py
@@ -1,9 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-import sqlite3
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -12,7 +8,8 @@ def test_PPReadIntermDatabase(tmp_path):
     from surveySimPP.modules.PPMakeIntermediatePointingDatabase import PPMakeIntermediatePointingDatabase
     from surveySimPP.modules.PPReadIntermDatabase import PPReadIntermDatabase
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
-    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 5, 'whitespace')
+    
+    padacl = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 5, 'whitespace')
     print(padacl)
     objid_list = padacl['ObjID'].unique().tolist()
 

--- a/surveySimPP/modules/tests/test_PPreadPhysicalParameters.py
+++ b/surveySimPP/modules/tests/test_PPreadPhysicalParameters.py
@@ -1,8 +1,5 @@
 #!/bin/python
 
-import pytest
-import pandas as pd
-
 from surveySimPP.tests.data import get_test_filepath
 
 
@@ -10,7 +7,7 @@ def test_PPReadPhysicalParameters():
     from surveySimPP.modules.PPReadPhysicalParameters import PPReadPhysicalParameters
     rescol = 0.3
 
-    padafr = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), 0, 3, "whitespace")
+    padafr = PPReadPhysicalParameters(get_test_filepath('testcolour.txt'), ['g-r', 'i-r', 'z-r'], 0, 3, "whitespace")
     val = padafr.at[0, 'g-r']
 
     assert rescol == val

--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -35,29 +35,36 @@ def runLSSTPostProcessing(cmd_args):
     # Initialise argument parser and assign command line arguments
 
     pplogger = PPGetLogger(cmd_args['outpath'])
+    pplogger.info('Post-processing begun.')
 
-    pplogger.info('Reading configuration file...')
+    # if verbosity flagged, the verboselog function will log the message specified
+    # if not, verboselog does absolutely nothing
+    verboselog = pplogger.info if cmd_args['verbose'] else lambda *a, **k: None
+
+    verboselog('Reading configuration file...')
     configs = PPConfigFileParser(cmd_args['configfile'], cmd_args['surveyname'])
 
-    pplogger.info('Configuration file successfully read.')
-    PPPrintConfigsToLog(configs)
+    verboselog('Configuration file successfully read.')
+
+    PPPrintConfigsToLog(configs, cmd_args)
 
     # End of config parsing
 
     if cmd_args['makeIntermediatePointingDatabase']:
         PPMakeIntermediatePointingDatabase(cmd_args['oifoutput'], './data/interm.db', 100)
 
-    pplogger.info('Reading pointing database and matching observationID with appropriate optical filter...')
+    verboselog('Reading pointing database and matching observationID with appropriate optical filter...')
+
     filterpointing = PPMatchPointing(configs['pointingdatabase'], configs['observing_filters'], configs['ppdbquery'])
 
-    pplogger.info('Instantiating random number generator ... ')
-    
+    verboselog('Instantiating random number generator ... ')
+
     if configs['rng_seed']:
         rng_seed = configs['rng_seed']
     else:
         rng_seed = int(time.time())
-    
-    pplogger.info('Random number seed is {}.'.format(rng_seed))
+
+    verboselog('Random number seed is {}.'.format(rng_seed))
     rng = np.random.default_rng(rng_seed)
 
     # In case of a large input file, the data is read in chunks. The
@@ -85,66 +92,66 @@ def runLSSTPostProcessing(cmd_args):
         # Processing begins, all processing is done for chunks
 
         observations = PPReadAllInput(cmd_args, configs, filterpointing,
-                                      startChunk, incrStep)
+                                      startChunk, incrStep, verbose=cmd_args['verbose'])
 
-        pplogger.info('Calculating apparent magnitudes...')
+        verboselog('Calculating apparent magnitudes...')
         observations = PPCalculateApparentMagnitude(observations,
                                                     configs['phasefunction'],
                                                     configs['mainfilter'],
                                                     configs['othercolours'],
                                                     configs['observing_filters'],
-                                                    configs['cometactivity'])
+                                                    configs['cometactivity'],
+                                                    verbose=cmd_args['verbose'])
 
         # ----------------------------------------------------------------------
         if configs['trailingLossesOn']:
-            pplogger.info('Calculating trailing losses...')
+            verboselog('Calculating trailing losses...')
             dmagDetect = PPTrailingLoss(observations, "circularPSF")
             observations['PSFMag'] = dmagDetect + observations['TrailedSourceMag']
         else:
             observations['PSFMag'] = observations['TrailedSourceMag']
         # ----------------------------------------------------------------------
 
-        pplogger.info('Calculating effects of vignetting on limiting magnitude...')
+        verboselog('Calculating effects of vignetting on limiting magnitude...')
         observations['fiveSigmaDepthAtSource'] = PPVignetting.vignettingEffects(observations)
 
-        
         # Note that the below code creates observedTrailedSourceMag and observedPSFMag
         # as columns in the observations dataframe.
         # These are the columns that should be used moving forward for filters etc.
         # Do NOT use TrailedSourceMag or PSFMag, these are cut later.
-        pplogger.info('Calculating astrometric and photometric uncertainties, randomizing photometry...')
+        verboselog('Calculating astrometric and photometric uncertainties, randomizing photometry...')
         observations = PPAddUncertainties.addUncertainties(observations, configs, rng)
 
-        pplogger.info('Applying astrometric uncertainties...')
+        verboselog('Applying astrometric uncertainties...')
         observations["AstRATrue(deg)"] = observations["AstRA(deg)"]
         observations["AstDecTrue(deg)"] = observations["AstDec(deg)"]
         observations["AstRA(deg)"], observations["AstDec(deg)"] = PPRandomizeMeasurements.randomizeAstrometry(observations, rng, sigName='AstrometricSigma(deg)')
 
-        pplogger.info('Applying field-of-view filters...')
-        observations = PPApplyFOVFilter(observations, configs, rng)
+        verboselog('Applying field-of-view filters...')
+        observations = PPApplyFOVFilter(observations, configs, rng, verbose=cmd_args['verbose'])
 
         if configs['SNRLimitOn']:
-            pplogger.info('Dropping observations with signal to noise ratio less than {}...'.format(configs['SNRLimit']))
+            verboselog('Dropping observations with signal to noise ratio less than {}...'.format(configs['SNRLimit']))
             observations = PPSNRLimit(observations, configs['SNRLimit'])
         else:
-            pplogger.info('Dropping observations with signal to noise ratio less than 2...')
+            verboselog('Dropping observations with signal to noise ratio less than 2...')
             observations = PPSNRLimit(observations, 2.0)
 
         if configs['magLimitOn']:
-            pplogger.info('Dropping detections fainter than user-defined magnitude limit... ')
+            verboselog('Dropping detections fainter than user-defined magnitude limit... ')
             observations = PPMagnitudeLimit(observations, configs['magLimit'])
 
         if configs['fadingFunctionOn']:
-            pplogger.info('Applying detection efficiency fading function...')
-            observations = PPFilterFadingFunction(observations, configs['fillfactor'], rng)
+            verboselog('Applying detection efficiency fading function...')
+            observations = PPFilterFadingFunction(observations, configs['fillfactor'], rng, verbose=cmd_args['verbose'])
 
         if configs['brightLimitOn']:
-            pplogger.info('Dropping observations that are too bright...')
+            verboselog('Dropping observations that are too bright...')
             observations = PPBrightLimit(observations, configs['brightLimit'])
 
         if configs['SSPLinkingOn']:
-            pplogger.info('Applying SSP linking filter...')
-            pplogger.info('Number of rows BEFORE applying SSP linking filter: ' + str(len(observations.index)))
+            verboselog('Applying SSP linking filter...')
+            verboselog('Number of rows BEFORE applying SSP linking filter: ' + str(len(observations.index)))
 
             observations = PPFilterSSPLinking(observations,
                                               configs['SSPDetectionEfficiency'],
@@ -156,10 +163,10 @@ def runLSSTPostProcessing(cmd_args):
 
             observations = observations.drop(['index'], axis='columns')
             observations.reset_index(drop=True, inplace=True)
-            pplogger.info('Number of rows AFTER applying SSP linking filter: ' + str(len(observations.index)))
+            verboselog('Number of rows AFTER applying SSP linking filter: ' + str(len(observations.index)))
 
         # write output
-        PPWriteOutput(cmd_args, configs, observations, endChunk)
+        PPWriteOutput(cmd_args, configs, observations, endChunk, verbose=cmd_args['verbose'])
 
         startChunk = startChunk + configs['sizeSerialChunk']
         # end for
@@ -187,6 +194,7 @@ def main():
          -o O, --orbit O    Orbit file name
          -p P, --pointing P  Pointing simulation output file name
          -s S, --survey S   Name of the survey you wish to simulate
+         -v V, --verbose    Verbosity on or off. Default is on.
     """
 
     parser = argparse.ArgumentParser()
@@ -199,6 +207,7 @@ def main():
     parser.add_argument("-s", "--survey", help="Survey to simulate", type=str, dest='s', default='LSST')
     parser.add_argument("-u", "--outfile", help="Path to store output and logs.", type=str, dest="u", default='./data/out/', required=True)
     parser.add_argument("-t", "--stem", help="Output file name stem.", type=str, dest="t", default='SSPPOutput')
+    parser.add_argument("-v", "--verbose", help="Verbosity. Default currently true; include to turn off verbosity.", dest='v', default=True, action='store_false')
 
     cmd_args = PPCMDLineParser(parser)
 


### PR DESCRIPTION
Fixes #65 .
PPReadPhysicalParameters now checks to make sure that the physical parameters file contains the colour offset columns which match the observing filters specified in the config file. If it doesn't, it errors out gracefully. Also changed many unit tests to reflect the fact that PPReadPhysicalParameters now takes 'othercolours' as an argument. All files I worked on are now PEP8 compliant.

Fixes #74.
There is now a verbose flag at the command line (-v). By default, it's True. If turned off, the only things printed to the log file are the command line arguments and config file variables for the run, in lieu of a header in the output.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
