### PR TITLE
Fixing #239, #248.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ The code can be installed by typing:
 pip install -e .
 ```
 
-Next, install the pointing database to the ./demo/ folder. This can be found [here](http://astro-lsst-01.astro.washington.edu:8080/?runId=1): click one of the links entitled 'baseline_v2.0_10yrs.db' near the top in the SQLite file column.
-
-
 Then the simulator can be run via:
 ```
 surveySimPP -c ./demo/PPConfig.ini -l ./demo/colours_10mbas.txt -o ./demo/orbits_10mbas.des -p ./demo/oif_10mbas.txt -u ./data/out/ -t demorun

--- a/demo/PPConfig.ini
+++ b/demo/PPConfig.ini
@@ -16,7 +16,7 @@
 ephemerides_type=oif
 
 # Location of pointing database.
-pointingdatabase = ./demo/baseline_v2.0_3yrs.db
+pointingdatabase = ./demo/baseline_v2.0_1yr.db
 #./data/test/baseline_10yrs_10klines.db 
 #'./data/baseline_v1.3_10yrs.db'# 
 # ./demo/baseline_v2.0_10yrs.db

--- a/demo/PPConfig.ini
+++ b/demo/PPConfig.ini
@@ -16,7 +16,7 @@
 ephemerides_type=oif
 
 # Location of pointing database.
-pointingdatabase = ./demo/baseline_v2.0_10yrs.db
+pointingdatabase = ./demo/baseline_v2.0_3yrs.db
 #./data/test/baseline_10yrs_10klines.db 
 #'./data/baseline_v1.3_10yrs.db'# 
 # ./demo/baseline_v2.0_10yrs.db

--- a/surveySimPP/modules/PPReadEphemerides.py
+++ b/surveySimPP/modules/PPReadEphemerides.py
@@ -1,8 +1,6 @@
 #!/bin/python
 
-import os
 import sys
-import pandas as pd
 import logging
 from . import PPReadOif
 
@@ -21,10 +19,10 @@ def PPReadEphemerides(eph_output, ephemerides_type, inputformat):
 
     For correct performance, the read-in data needs to contain all of the following columns:
 
-    ['ObjID', 'FieldID', 'FieldMJD', 'AstRange(km)', 'AstRangeRate(km/s)', 'AstRA(deg)', 
+    ['ObjID', 'FieldID', 'FieldMJD', 'AstRange(km)', 'AstRangeRate(km/s)', 'AstRA(deg)',
     'AstRARate(deg/day)', 'AstDec(deg)', 'AstDecRate(deg/day)', 'Ast-Sun(J2000x)(km)', 'Ast-Sun(J2000y)(km)',
-    'Ast-Sun(J2000z)(km)', 'Ast-Sun(J2000vx)(km/s)', 'Ast-Sun(J2000vy)(km/s)', 'Ast-Sun(J2000vz)(km/s)', 
-    'Obs-Sun(J2000x)(km)', 'Obs-Sun(J2000y)(km)', 'Obs-Sun(J2000z)(km)', 'Obs-Sun(J2000vx)(km/s)', 
+    'Ast-Sun(J2000z)(km)', 'Ast-Sun(J2000vx)(km/s)', 'Ast-Sun(J2000vy)(km/s)', 'Ast-Sun(J2000vz)(km/s)',
+    'Obs-Sun(J2000x)(km)', 'Obs-Sun(J2000y)(km)', 'Obs-Sun(J2000z)(km)', 'Obs-Sun(J2000vx)(km/s)',
     'Obs-Sun(J2000vy)(km/s)', 'Obs-Sun(J2000vz)(km/s)', 'Sun-Ast-Obs(deg)']
 
 
@@ -32,7 +30,7 @@ def PPReadEphemerides(eph_output, ephemerides_type, inputformat):
 
 
     Mandatory input:      string, eph_output, name of text file including Output from ephemerides file
-                          string, ephemerides_type, type of ephemerides pointing simulation (oif) 
+                          string, ephemerides_type, type of ephemerides pointing simulation (oif)
                           string, inputformat, input format of pointing putput (csv, whitespace, hdf5)
 
 
@@ -42,17 +40,16 @@ def PPReadEphemerides(eph_output, ephemerides_type, inputformat):
 
     usage: PPReadEphemerides(padafr, ephemerides_type, inputformat)
     """
-    #from surveySimPP.modules.PPRunUtilities import PPGetLogger
+
     pplogger = logging.getLogger(__name__)
-    
-    ephtypeci=ephemerides_type.casefold()
+
+    ephtypeci = ephemerides_type.casefold()
 
     if (ephtypeci == 'oif'):
         padafr = PPReadOif.PPReadOif(eph_output, inputformat)
-        
     else:
-       pplogger.error("PPReadEphemerides: invalid value for ephemerides_type: " + str(ephemerides_type))
-       sys.exit("PPReadEphemerides: invalid value for ephemerides_type: " + str(ephemerides_type))
+        pplogger.error("PPReadEphemerides: invalid value for ephemerides_type: " + str(ephemerides_type))
+        sys.exit("PPReadEphemerides: invalid value for ephemerides_type: " + str(ephemerides_type))
 
     # Functions for adding alternative types of ephemerides can be added here
     # See below for self-explanatory columns required for the ephemerides input

--- a/surveySimPP/modules/PPReadEphemerides.py
+++ b/surveySimPP/modules/PPReadEphemerides.py
@@ -65,9 +65,8 @@ def PPReadEphemerides(eph_output, ephemerides_type, inputformat):
             'Obs-Sun(J2000x)(km)', 'Obs-Sun(J2000y)(km)', 'Obs-Sun(J2000z)(km)', 'Obs-Sun(J2000vx)(km/s)',
             'Obs-Sun(J2000vy)(km/s)', 'Obs-Sun(J2000vz)(km/s)', 'Sun-Ast-Obs(deg)']
 
-    for col in cols:
-        if col not in padafr:
-            pplogger.error('ERROR: PPReadEphemerides: essential columns missing from ephemerides input: ', col)
-            sys.exit('ERROR: PPReadEphemerides: essential columns missing from ephemerides input: ', col)
+    if not all(col in padafr.columns for col in cols):
+        pplogger.error('ERROR: PPReadEphemerides: essential columns missing from ephemerides input. Required columns are: {}'.format(cols))
+        sys.exit('ERROR: PPReadEphemerides: essential columns missing from ephemerides input. Required columns are: {}'.format(cols))
 
     return padafr

--- a/surveySimPP/modules/PPReadOif.py
+++ b/surveySimPP/modules/PPReadOif.py
@@ -53,7 +53,7 @@ def PPReadOif(oif_output, inputformat):
     # as they can be calculated with a variety of phase functions, and in different filters
 
     padafr = padafr.drop(['V', 'V(H=0)'], axis=1, errors='ignore')
-    
+
     try:
         padafr['ObjID'] = padafr['ObjID'].astype(str)
     except KeyError:

--- a/surveySimPP/modules/PPReadOif.py
+++ b/surveySimPP/modules/PPReadOif.py
@@ -44,8 +44,8 @@ def PPReadOif(oif_output, inputformat):
     elif (inputformat == 'h5') or (inputformat == 'hdf5') or (inputformat == 'HDF5'):
         padafr = pd.read_hdf(oif_output).reset_index(drop=True)
     else:
-        pplogger.error("ERROR: PPReadOif: unknown format for pointing simulation results.")
-        sys.exit("ERROR: PPReadOif: unknown format for pointing simulation results.")
+        pplogger.error("ERROR: PPReadOif: unknown format for ephemeris simulation results.")
+        sys.exit("ERROR: PPReadOif: unknown format for ephemeris simulation results.")
 
     padafr = padafr.rename(columns=lambda x: x.strip())
 
@@ -53,6 +53,11 @@ def PPReadOif(oif_output, inputformat):
     # as they can be calculated with a variety of phase functions, and in different filters
 
     padafr = padafr.drop(['V', 'V(H=0)'], axis=1, errors='ignore')
-    padafr['ObjID'] = padafr['ObjID'].astype(str)
+    
+    try:
+        padafr['ObjID'] = padafr['ObjID'].astype(str)
+    except KeyError:
+        pplogger.error("ERROR: ephemeris input file does not have 'ObjID' column.")
+        sys.exit("ERROR: ephemeris input file does not have 'ObjID' column.")
 
     return padafr


### PR DESCRIPTION
Fixes #269.
Streamlined a for-loop in PPReadEphemerides.py and made it PEP8 compliant.

Fixes #248.
There is now a smaller version of the pointing database for the demo run: it is just one year of the pointing data and is in demo/baseline_v2_1yr.db. I have tested it and for the demo inputs and config file, it results in a small output of around 25 lines. 

Also, I found an uncaught error in PPReadOif.py if the ephemerides input file does not have a column named "ObjID". This error has now been caught and fails gracefully.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
