### PR TITLE
Rewriting SSP linking filter.

### DIFF
--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -165,7 +165,6 @@ def runLSSTPostProcessing(cmd_args):
                                               configs['inSepThreshold'],
                                               rng)
 
-            observations = observations.drop(['index'], axis='columns')
             observations.reset_index(drop=True, inplace=True)
             verboselog('Number of rows AFTER applying SSP linking filter: ' + str(len(observations.index)))
 


### PR DESCRIPTION
Fixes #264.

Rewrote PPFilterSSPLinking.py to be a _lot_ faster: on a test input of a 900-line Pandas dataframe, it's 30x faster than the old function. It should also be clearer. I've left a lot of comments on the code.

There's no error handling in the function because all error handling for the relevant variables is done at the start of the code when the config file is parsed.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
