### PR TITLE
Fixing #285, small tweaks.

### DIFF
--- a/demo/PPConfig.ini
+++ b/demo/PPConfig.ini
@@ -152,7 +152,11 @@ outputformat = csv
 # Options are "default" only. More may be added later.
 outputsize = default
 
+# Decimal places RA and Dec should be rounded to in output. Default is 7.
+position_decimals = 7
 
+# Decimal places magnitudes should be rounded to in output. Default is 3. 
+magnitude_decimals = 3
 
 
 

--- a/surveySimPP/modules/PPConfigParser.py
+++ b/surveySimPP/modules/PPConfigParser.py
@@ -323,6 +323,13 @@ def PPConfigFileParser(configfile, survey_name):
         pplogger.error('ERROR: outputsize should be "default".')
         sys.exit('ERROR: outputsize should be "default".')
 
+    config_dict["position_decimals"] = PPGetIntOrExit(config, 'OUTPUTFORMAT', 'position_decimals', 'ERROR: positional decimal places not specified.')
+    config_dict["magnitude_decimals"] = PPGetIntOrExit(config, 'OUTPUTFORMAT', 'magnitude_decimals', 'ERROR: magnitude decimal places not specified.')
+
+    if config_dict["position_decimals"] < 0 or config_dict["magnitude_decimals"] < 0:
+        pplogger.error('ERROR: decimal places config variables cannot be negative.')
+        sys.exit('ERROR: decimal places config variables cannot be negative.')
+
     # size of chunk
 
     config_dict['sizeSerialChunk'] = PPGetIntOrExit(config, 'GENERAL', 'sizeSerialChunk', 'ERROR: sizeSerialChunk not specified.')
@@ -425,3 +432,5 @@ def PPPrintConfigsToLog(configs, cmd_args):
         pplogger.info('Solar System Processing linking filter is turned OFF.')
 
     pplogger.info('Output files will be saved in path: ' + cmd_args['outpath'] + ' with filestem ' + cmd_args['outfilestem'])
+    pplogger.info('In the output, positions will be rounded to ' + str(configs['position_decimals']) + ' decimal places.')
+    pplogger.info('In the output, magnitudes will be rounded to ' + str(configs['magnitude_decimals']) + ' decimal places.')

--- a/surveySimPP/modules/PPOutput.py
+++ b/surveySimPP/modules/PPOutput.py
@@ -89,13 +89,21 @@ def PPWriteOutput(cmd_args, configs, observations_in, endChunk, verbose=False):
     verboselog = pplogger.info if verbose else lambda *a, **k: None
 
     if configs['outputsize'] == 'default':
-        observations = observations_in[['ObjID', 'FieldMJD', 'fieldRA', 'fieldDec',
-                                        'AstRA(deg)', 'AstDec(deg)', 'AstrometricSigma(deg)',
-                                        'optFilter', 'observedPSFMag', 'observedTrailedSourceMag',
-                                        'PhotometricSigmaPSF(mag)', 'PhotometricSigmaTrailedSource(mag)',
-                                        'fiveSigmaDepth', 'fiveSigmaDepthAtSource']]
-    # else:
-        # observations = observations_in
+        observations = observations_in.copy()[['ObjID', 'FieldMJD', 'fieldRA', 'fieldDec',
+                                               'AstRA(deg)', 'AstDec(deg)', 'AstrometricSigma(deg)',
+                                               'optFilter', 'observedPSFMag', 'observedTrailedSourceMag',
+                                               'PhotometricSigmaPSF(mag)', 'PhotometricSigmaTrailedSource(mag)',
+                                               'fiveSigmaDepth', 'fiveSigmaDepthAtSource']]
+    else:
+        observations = observations_in.copy()
+
+    observations['FieldMJD'] = observations['FieldMJD'].round(decimals=5)
+
+    for position_col in ['fieldRA', 'fieldDec', 'AstRA(deg)', 'AstDec(deg)', 'AstrometricSigma(deg)']:
+        observations[position_col] = observations[position_col].round(decimals=configs["position_decimals"])
+
+    for magnitude_col in ['observedPSFMag', 'observedTrailedSourceMag', 'PhotometricSigmaPSF(mag)', 'PhotometricSigmaTrailedSource(mag)', 'fiveSigmaDepth', 'fiveSigmaDepthAtSource']:
+        observations[magnitude_col] = observations[magnitude_col].round(decimals=configs["magnitude_decimals"])
 
     verboselog('Constructing output path...')
 

--- a/surveySimPP/modules/PPReadEphemerides.py
+++ b/surveySimPP/modules/PPReadEphemerides.py
@@ -63,4 +63,4 @@ def PPReadEphemerides(eph_output, ephemerides_type, inputformat):
         pplogger.error('ERROR: PPReadEphemerides: essential columns missing from ephemerides input. Required columns are: {}'.format(cols))
         sys.exit('ERROR: PPReadEphemerides: essential columns missing from ephemerides input. Required columns are: {}'.format(cols))
 
-    return padafr
+    return padafr[cols]

--- a/surveySimPP/modules/PPReadOrbitFile.py
+++ b/surveySimPP/modules/PPReadOrbitFile.py
@@ -52,7 +52,7 @@ def PPReadOrbitFile(orbin, beginLoc, chunkSize, filesep):
         pplogger.error(outstr)
         sys.exit(outstr)
 
-    padafr = padafr.drop(['INDEX', 'N_PAR', 'MOID', 'COMPCODE'], axis=1, errors='ignore')
+    padafr = padafr.drop(['INDEX', 'N_PAR', 'MOID', 'COMPCODE', 'FORMAT'], axis=1, errors='ignore')
     padafr['ObjID'] = padafr['ObjID'].astype(str)
 
     return padafr

--- a/surveySimPP/modules/tests/test_PPConfigParser.py
+++ b/surveySimPP/modules/tests/test_PPConfigParser.py
@@ -62,6 +62,8 @@ def test_PPConfigFileParser(setup_and_teardown_for_PPConfigFileParser):
                     'SSPLinkingOn': True,
                     'outputformat': 'csv',
                     'outputsize': 'default',
+                    'position_decimals': 7,
+                    'magnitude_decimals': 3,
                     'sizeSerialChunk': 10,
                     'rng_seed': None}
 

--- a/surveySimPP/modules/tests/test_PPJoinOrbitalData.py
+++ b/surveySimPP/modules/tests/test_PPJoinOrbitalData.py
@@ -3,7 +3,7 @@
 from surveySimPP.tests.data import get_test_filepath
 
 
-def test_PPJoinCOrbitalData():
+def test_PPJoinOrbitalData():
 
     from surveySimPP.modules.PPJoinOrbitalData import PPJoinOrbitalData
     from surveySimPP.modules.PPJoinPhysicalParametersPointing import PPJoinPhysicalParametersPointing
@@ -18,7 +18,7 @@ def test_PPJoinCOrbitalData():
     padain = PPJoinPhysicalParametersPointing(padafr, padacl)
     padare = PPJoinOrbitalData(padain, padaor)
 
-    ncol = 35
+    ncol = 34
     ncolre = len(padare.columns)
 
     assert ncol == ncolre

--- a/surveySimPP/modules/tests/test_PPReadOrbitFile.py
+++ b/surveySimPP/modules/tests/test_PPReadOrbitFile.py
@@ -5,7 +5,7 @@ from surveySimPP.tests.data import get_test_filepath
 
 def test_PPReadOrbitFile():
     from surveySimPP.modules.PPReadOrbitFile import PPReadOrbitFile
-    rescol = 9
+    rescol = 8
 
     padafr = PPReadOrbitFile(get_test_filepath('testorb.des'), 0, 14, "whitespace")
     val = len(padafr.columns)

--- a/surveySimPP/tests/data/test_PPConfig.ini
+++ b/surveySimPP/tests/data/test_PPConfig.ini
@@ -147,6 +147,13 @@ outputformat = csv
 # Options are "default" only. More may be added later.
 outputsize = default
 
+# Decimal places RA and Dec should be rounded to in output. Default is 7.
+position_decimals = 7
+
+# Decimal places magnitudes should be rounded to in output. Default is 3. 
+magnitude_decimals = 3
+
+
 
 
 


### PR DESCRIPTION
Fixes #285.
The decimal places of the output are now controlled by two config file variables for positional values and for magnitude values. The defaults are 7 and 3 respectively. MJDs are given to 5 decimal places, hardcoded.

Fixes #282.
Some extraneous/unneeded columns are no longer read in from the input files.

Fixes #283.
Or at least this issue can be closed, as I had already included error handling for this issue and had missed it when I went looking for it earlier.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
