### PR TITLE
Fixing #302, adding configs for end-to-end test run.

### DIFF
--- a/demo/OIFconfig_test.ini
+++ b/demo/OIFconfig_test.ini
@@ -1,0 +1,29 @@
+[CONF]
+cache dir = _cache/sspp_testset_orbits/1-10
+
+[ASTEROID]
+population model = ./demo/sspp_testset_orbits.des
+spk t0 = 60188
+ndays = 395
+object1 = 1
+nobjects = 10
+spk step = 1
+nbody = T
+input format = whitespace
+
+[SURVEY]
+survey database = ./demo/baseline_v2.0_1yr.db
+field1 = 1
+nfields = 216011
+mpcobscode file = obslist.dat
+telescope = I11
+surveydbquery = SELECT observationId,observationStartMJD,fieldRA,fieldDEC,rotSkyPos FROM observations order by observationStartMJD
+
+[CAMERA]
+threshold = 5
+camera = instrument_circle.dat
+
+[OUTPUT]
+output file = stdout
+output format = csv
+

--- a/surveySimPP/modules/PPMakeIntermediateEphemerisDatabase.py
+++ b/surveySimPP/modules/PPMakeIntermediateEphemerisDatabase.py
@@ -4,6 +4,7 @@ import pandas as pd
 import sqlite3
 import logging
 import sys
+from .PPReadOif import PPSkipOifHeader
 
 # Author: Grigori fedorets and Steph Merritt
 
@@ -36,9 +37,9 @@ def PPMakeIntermediateEphemerisDatabase(oif_output, outf, inputformat):
     cur.execute(cmd)
 
     if (inputformat == "whitespace"):
-        padafr = pd.read_csv(oif_output, delim_whitespace=True)
+        padafr = PPSkipOifHeader(oif_output, 'ObjID', delim_whitespace=True)
     elif (inputformat == "comma") or (inputformat == 'csv'):
-        padafr = pd.read_csv(oif_output, delimiter=',')
+        padafr = PPSkipOifHeader(oif_output, 'ObjID', delimiter=',')
     elif (inputformat == 'h5') or (inputformat == 'hdf5') or (inputformat == 'HDF5'):
         padafr = pd.read_hdf(oif_output).reset_index(drop=True)
     else:

--- a/surveySimPP/modules/PPReadOif.py
+++ b/surveySimPP/modules/PPReadOif.py
@@ -38,9 +38,9 @@ def PPReadOif(oif_output, inputformat):
     pplogger = logging.getLogger(__name__)
 
     if (inputformat == "whitespace"):
-        padafr = PPSkipOifHeader(oif_output, delim_whitespace=True)
+        padafr = PPSkipOifHeader(oif_output, 'ObjID,', delim_whitespace=True)
     elif (inputformat == "comma") or (inputformat == 'csv'):
-        padafr = PPSkipOifHeader(oif_output, 'ObjID', delimiter=',')
+        padafr = PPSkipOifHeader(oif_output, 'ObjID,', delimiter=',')
     elif (inputformat == 'h5') or (inputformat == 'hdf5') or (inputformat == 'HDF5'):
         padafr = pd.read_hdf(oif_output).reset_index(drop=True)
     else:

--- a/surveySimPP/modules/PPReadOif.py
+++ b/surveySimPP/modules/PPReadOif.py
@@ -65,24 +65,24 @@ def PPReadOif(oif_output, inputformat):
 
 def PPSkipOifHeader(filename, line_start='ObjID', **kwargs):
     """Utility function that scans through the lines of OIF output looking for
-    the column names then passes the file object to pandas starting from that 
+    the column names then passes the file object to pandas starting from that
     line, thus skipping the long OIF header.
     """
 
     with open(filename) as f:
-        
+
         position = 0
         current_line = f.readline()
-        
+
         # reads the file line by line looking for the line that starts with
         # the expected string
         while not current_line.startswith(line_start):
             position = f.tell()
             current_line = f.readline()
-        
+
         # changes the file position to the start of the line that begins
         # with the desired string
         f.seek(position)
-        
+
         # passes that file object to pandas
         return pd.read_csv(f, **kwargs)

--- a/surveySimPP/modules/PPReadOif.py
+++ b/surveySimPP/modules/PPReadOif.py
@@ -38,9 +38,9 @@ def PPReadOif(oif_output, inputformat):
     pplogger = logging.getLogger(__name__)
 
     if (inputformat == "whitespace"):
-        padafr = pd.read_csv(oif_output, delim_whitespace=True)
+        padafr = PPSkipOifHeader(oif_output, delim_whitespace=True)
     elif (inputformat == "comma") or (inputformat == 'csv'):
-        padafr = pd.read_csv(oif_output, delimiter=',')
+        padafr = PPSkipOifHeader(oif_output, 'ObjID', delimiter=',')
     elif (inputformat == 'h5') or (inputformat == 'hdf5') or (inputformat == 'HDF5'):
         padafr = pd.read_hdf(oif_output).reset_index(drop=True)
     else:
@@ -61,3 +61,28 @@ def PPReadOif(oif_output, inputformat):
         sys.exit("ERROR: ephemeris input file does not have 'ObjID' column.")
 
     return padafr
+
+
+def PPSkipOifHeader(filename, line_start='ObjID', **kwargs):
+    """Utility function that scans through the lines of OIF output looking for
+    the column names then passes the file object to pandas starting from that 
+    line, thus skipping the long OIF header.
+    """
+
+    with open(filename) as f:
+        
+        position = 0
+        current_line = f.readline()
+        
+        # reads the file line by line looking for the line that starts with
+        # the expected string
+        while not current_line.startswith(line_start):
+            position = f.tell()
+            current_line = f.readline()
+        
+        # changes the file position to the start of the line that begins
+        # with the desired string
+        f.seek(position)
+        
+        # passes that file object to pandas
+        return pd.read_csv(f, **kwargs)

--- a/surveySimPP/modules/PPReadOif.py
+++ b/surveySimPP/modules/PPReadOif.py
@@ -38,9 +38,9 @@ def PPReadOif(oif_output, inputformat):
     pplogger = logging.getLogger(__name__)
 
     if (inputformat == "whitespace"):
-        padafr = PPSkipOifHeader(oif_output, 'ObjID,', delim_whitespace=True)
+        padafr = PPSkipOifHeader(oif_output, 'ObjID', delim_whitespace=True)
     elif (inputformat == "comma") or (inputformat == 'csv'):
-        padafr = PPSkipOifHeader(oif_output, 'ObjID,', delimiter=',')
+        padafr = PPSkipOifHeader(oif_output, 'ObjID', delimiter=',')
     elif (inputformat == 'h5') or (inputformat == 'hdf5') or (inputformat == 'HDF5'):
         padafr = pd.read_hdf(oif_output).reset_index(drop=True)
     else:


### PR DESCRIPTION
Fixes #302.
When opening OIF output (or indeed any ephemeris output) the code now skips everything before the column names (it searches for a line beginning 'ObjID' and starts reading from there).

This circumvents the OIF output headers without deleting them, and is also generalisable: it'll work for just about any random header that might be in the ephemeris input.

I've also included OIF and SSPP config files in the demo folder. For a full end-to-end test run, _from the main survey_simulator_post_processing repo folder_:

`oif -f ./demo/OIFconfig_test.ini > ./demo/test_oif_output.txt`

`surveySimPP -c ./demo/PPConfig_test.ini -l ./demo/sspp_testset_colours.txt -o ./demo/sspp_testset_orbits.des -p ./demo/test_oif_output.txt -u ./data/out/ -t testrun_e2e`

If you want to run the commands anywhere else, the filepaths in OIFConfig.ini file will have to be altered. Note that if you're using relative paths in the OIF config file, they have to be explicitly relative (i.e., begin with . or ./) or OIF will assume the files are in the /data/ directory in its source code and get very confused.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
