### PR TITLE
Adding utility scripts, fixing three issues.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,8 @@ console_scripts =
     surveySimPP = surveySimPP.surveySimPP:main
     makeConfigOIF = surveySimPP.utilities.makeConfigOIF:main
     makeConfigPP = surveySimPP.utilities.makeConfigPP:main
+    makeMultiConfigOIF = surveySimPP.utilities.makeMultiConfigOIF:main
+    makeSLURMscript = surveySimPP.utilities.makeSLURMscript:main
 
 [options.extras_require]
 test =

--- a/surveySimPP/modules/PPCMDLineParser.py
+++ b/surveySimPP/modules/PPCMDLineParser.py
@@ -37,7 +37,8 @@ def PPCMDLineParser(parser):
         cmd_args_dict['cometinput'] = PPFindFileOrExit(args.m, '-m, --comet')
 
     cmd_args_dict['makeIntermediateEphemerisDatabase'] = bool(args.dw)
-    cmd_args_dict['readIntermediateEphemerisDatabase'] = bool(args.dr)
+    cmd_args_dict['readIntermediateEphemerisDatabase'] = args.dr
+    cmd_args_dict['deleteIntermediateEphemerisDatabase'] = bool(args.dl)
     cmd_args_dict['surveyname'] = args.s
     cmd_args_dict['outfilestem'] = args.t
     cmd_args_dict['verbose'] = args.v
@@ -46,8 +47,12 @@ def PPCMDLineParser(parser):
         pplogger.error('ERROR: both -dr and -dw flags set at command line. Please use only one.')
         sys.exit('ERROR: both -dr and -dw flags set at command line. Please use only one.')
 
-    if args.dr and not os.path.exists(cmd_args_dict['outpath'] + 'interm.db'):
-        pplogger.error('ERROR: intermediate ephemeris database not found at ' + cmd_args_dict['outpath'] + 'interm.db. Rerun with command line flag -dw to create one.')
-        sys.exit('ERROR: intermediate ephemeris database not found at ' + cmd_args_dict['outpath'] + 'interm.db. Rerun with command line flag -dw to create one.')
+    if args.dl and not args.dr and not args.dw:
+        pplogger.error('ERROR: -dl flag set without either -dr or -dw.')
+        sys.exit('ERROR: -dl flag set without either -dr or -dw.')
+
+    if args.dr and not os.path.exists(args.dr):
+        pplogger.error('ERROR: interim ephemeris database not found at ' + args.dr + '. Rerun with command line flag -dw to create one.')
+        sys.exit('ERROR: interim ephemeris database not found at ' + args.dr + '. Rerun with command line flag -dw to create one.')
 
     return cmd_args_dict

--- a/surveySimPP/modules/PPMakeIntermediateEphemerisDatabase.py
+++ b/surveySimPP/modules/PPMakeIntermediateEphemerisDatabase.py
@@ -4,6 +4,8 @@ import pandas as pd
 import sqlite3
 import logging
 import sys
+import os
+from datetime import datetime
 from .PPReadOif import PPSkipOifHeader
 
 # Author: Grigori fedorets and Steph Merritt
@@ -29,7 +31,12 @@ def PPMakeIntermediateEphemerisDatabase(oif_output, outf, inputformat):
 
     pplogger = logging.getLogger(__name__)
 
-    cnx = sqlite3.connect(outf)
+    dstr = datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
+    cpid = os.getpid()
+
+    inter_name = dstr + '-p' + str(cpid) + '-' + 'interim.db'
+
+    cnx = sqlite3.connect(outf + inter_name)
 
     cur = cnx.cursor()
 
@@ -48,4 +55,4 @@ def PPMakeIntermediateEphemerisDatabase(oif_output, outf, inputformat):
 
     padafr.to_sql("interm", con=cnx, if_exists="append", index=False)
 
-    return outf
+    return outf + inter_name

--- a/surveySimPP/modules/PPReadAllInput.py
+++ b/surveySimPP/modules/PPReadAllInput.py
@@ -49,7 +49,7 @@ def PPReadAllInput(cmd_args, configs, filterpointing, startChunk, incrStep, verb
     if cmd_args['makeIntermediateEphemerisDatabase'] or cmd_args['readIntermediateEphemerisDatabase']:
         # read from intermediate database
         verboselog('Reading from intermediate ephemeris database.')
-        padafr = PPReadIntermediateEphemerisDatabase(cmd_args['outpath']+'interm.db', objid_list)
+        padafr = PPReadIntermediateEphemerisDatabase(cmd_args['readIntermediateEphemerisDatabase'], objid_list)
     else:
         try:
             verboselog('Reading input pointing history: ' + cmd_args['oifoutput'])

--- a/surveySimPP/modules/tests/test_PPReadIntermediateEphemerisDatabase.py
+++ b/surveySimPP/modules/tests/test_PPReadIntermediateEphemerisDatabase.py
@@ -16,7 +16,7 @@ def test_PPReadIntermediateEphemerisDatabase(tmp_path):
     testdb = str(tmp_path / "testdb_PPIntermDB.db")
     daba = PPMakeIntermediateEphemerisDatabase(get_test_filepath('oiftestoutput.txt'), testdb, 'whitespace')
 
-    padafr = PPReadIntermediateEphemerisDatabase(testdb, objid_list)
+    padafr = PPReadIntermediateEphemerisDatabase(daba, objid_list)
 
     nlines = 9
 

--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -4,6 +4,7 @@ import sys
 import time
 import numpy as np
 import argparse
+import os
 
 from surveySimPP.modules.PPMatchPointing import PPMatchPointing
 from surveySimPP.modules.PPFilterSSPLinking import PPFilterSSPLinking
@@ -55,7 +56,8 @@ def runLSSTPostProcessing(cmd_args):
     # End of config parsing
 
     if cmd_args['makeIntermediateEphemerisDatabase']:
-        PPMakeIntermediateEphemerisDatabase(cmd_args['oifoutput'], cmd_args['outpath']+'interm.db', configs["ephFormat"])
+        verboselog('Creating intermediate ephemeris database...')
+        cmd_args['readIntermediateEphemerisDatabase'] = PPMakeIntermediateEphemerisDatabase(cmd_args['oifoutput'], cmd_args['outpath'], configs["ephFormat"])
 
     verboselog('Reading pointing database and matching observationID with appropriate optical filter...')
 
@@ -92,8 +94,8 @@ def runLSSTPostProcessing(cmd_args):
             incrStep = configs['sizeSerialChunk']
         else:
             incrStep = lenf - startChunk
-            
-        verboselog('Working on objects {}-{}.'.format(startChunk, endChunk)) 
+
+        verboselog('Working on objects {}-{}.'.format(startChunk, endChunk))
 
         # Processing begins, all processing is done for chunks
 
@@ -176,6 +178,10 @@ def runLSSTPostProcessing(cmd_args):
         startChunk = startChunk + configs['sizeSerialChunk']
         # end for
 
+    if cmd_args['deleteIntermediateEphemerisDatabase']:
+        verboselog('Deleting the intermediate ephemeris database...')
+        os.remove(cmd_args['readIntermediateEphemerisDatabase'])
+
     pplogger.info('Post processing completed.')
 
 
@@ -208,7 +214,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", help="Input configuration file name", type=str, dest='c', default='./PPConfig.ini', required=True)
     parser.add_argument("-dw", help="Make intermediate ephemeris database. Overwrites existing database if present.", dest='dw', action='store_true')
-    parser.add_argument("-dr", help="Read from existing/previous intermediate ephemeris database.", dest='dr', action='store_true')
+    parser.add_argument("-dr", help="Read from existing/previous intermediate ephemeris database.", dest='dr', type=str)
+    parser.add_argument("-dl", help="Delete the interim database after code has completed.", action='store_true', default=False)
     parser.add_argument("-m", "--comet", help="Comet parameter file name", type=str, dest='m')
     parser.add_argument("-l", "--params", help="Physical parameters file name", type=str, dest='l', default='./data/params', required=True)
     parser.add_argument("-o", "--orbit", help="Orbit file name", type=str, dest='o', default='./data/orbit.des', required=True)

--- a/surveySimPP/utilities/makeConfigPP.py
+++ b/surveySimPP/utilities/makeConfigPP.py
@@ -114,5 +114,6 @@ def main():
 
     makeConfigFile(args)
 
+
 if __name__ == '__main__':
     main()

--- a/surveySimPP/utilities/makeConfigPP.py
+++ b/surveySimPP/utilities/makeConfigPP.py
@@ -114,5 +114,5 @@ def main():
 
     makeConfigFile(args)
 
-    if __name__ == '__main__':
-        main()
+if __name__ == '__main__':
+    main()

--- a/surveySimPP/utilities/makeMultiConfigOIF.py
+++ b/surveySimPP/utilities/makeMultiConfigOIF.py
@@ -1,0 +1,125 @@
+import configparser
+import argparse
+import pandas as pd
+import numpy as np
+import os
+import sqlite3 as sql
+import sys
+import glob
+
+
+def makeConfig(args):
+
+    # grab defaults from a template config file
+    config = configparser.ConfigParser()
+
+    # get database info
+    con = sql.connect(args.pointing)
+    database = pd.read_sql_query("SELECT observationStartMJD, observationId FROM observations ORDER BY observationStartMJD", con)
+    # maxFields = len(database.index)
+
+    # get what dates to check in database
+    survey_days = database["observationStartMJD"].astype(int).unique()
+
+    day1 = survey_days[args.day1 - 1]
+
+    # get the final day and the total number of days to run over
+    if (args.ndays == -1) or (args.ndays + args.day1 >= survey_days.iloc[-1]):
+        dayf = survey_days[-1]
+        ndays = int(np.floor(survey_days[-1] - day1) + 1)
+    else:
+        dayf = day1 + args.ndays
+        ndays = args.ndays
+
+    # get range of fields for those days
+    field1 = database.loc[(database["observationStartMJD"] - day1) < 1.0]["observationId"].iloc[0]
+    fieldf = database.loc[(database["observationStartMJD"] - dayf) < 2.0]["observationId"].iloc[-1]  # this will likely overshoot a little bit
+    
+    orbits_list = glob.glob(args.o+'orbits*.txt')
+    
+    for fn in orbits_list:
+        
+        if (args.inputformat == 'whitespace'):
+            orbits = pd.read_csv(fn, delim_whitespace=True)
+        else:
+            orbits = pd.read_csv(fn)
+
+        nOrbitsTotal = len(orbits.index)
+        
+        orbits_name = os.path.basename(os.path.splitext(fn)[0])[7:]
+
+        config.read_dict({
+            'CONF': {
+                'Cache dir': args.cache + "/" + orbits_name
+            },
+            'ASTEROID': {
+                'population model': os.path.abspath(fn),
+                'SPK T0': str(day1 - 30),
+                'nDays': str(ndays + 30),
+                'Object1': 1,
+                'nObjects': str(nOrbitsTotal),
+                'SPK step': str(args.spkstep),
+                'nbody': 'T',
+                'input format': args.inputformat
+            },
+            'SURVEY': {
+                'Survey database': os.path.abspath(args.pointing),
+                'Field1': str(field1 + 1),
+                'nFields': str(fieldf - field1),
+                'MPCobscode file': args.mpcfile,
+                'Telescope': args.telescope,
+                'Surveydbquery': 'SELECT observationId,observationStartMJD,fieldRA,fieldDEC,rotSkyPos FROM observations order by observationStartMJD'
+            },
+            'CAMERA': {
+                'Threshold': '5',
+                'Camera': args.camerafov,
+            },
+            'OUTPUT': {
+                'Output file': 'stdout',
+                'Output format': 'csv'
+            }
+        })
+
+        ndigits = len(str(len(orbits.index)))
+        with open(args.o+'config_' + orbits_name + '.ini', 'w') as file:
+            config.write(file)
+
+
+def main():
+
+    parser = argparse.ArgumentParser(description='creating config file(s) for Objects in Field')
+    parser.add_argument("o", help="orbits file path location", type=str)
+    parser.add_argument("pointing", help="pointing database location", type=str)
+    parser.add_argument("-no", help="number of orbits per config file, -1 runs all the orbits in one config file. Default value = 300", type=int, default=300)
+    parser.add_argument("-ndays", help="number of days in survey to run, -1 runs entire survey. Default value = -1", type=int, default=-1)
+    parser.add_argument("-day1", help="first day in survey to run. Default value = 1", type=int, default=1)
+    parser.add_argument("-prefix", help="config file name prefix, Default value is an empty string", type=str, default='')
+    parser.add_argument("-camerafov", help='path and file name of the camera fov. Default value = instrument_polygon.dat', type=str, default='instrument_polygon.dat')
+    parser.add_argument("-inputformat", help='input format (CSV or whitespace). Default value = whitespace', type=str, default='whitespace')
+    parser.add_argument("-cache", help='base cache directory name. Default value = _cache', type=str, default='_cache')
+    parser.add_argument("-mpcfile", help='name of the file containing the MPC observatory codes. Default value = obslist.dat', type=str, default='obslist.dat')
+    parser.add_argument("-spkstep", help="Integration step in days. Default value = 30", type=int, default=30)
+    parser.add_argument("-telescope", help="Observatory MPC Code. Default value = I11 (Gemini South to be changed to Rubin Observatory)", type=str, default='I11')
+
+    args = parser.parse_args()
+
+    # error checks that optional inputs are within the right range
+
+    if (args.inputformat != 'whitespace') and (args.inputformat != 'CSV'):
+        sys.exit('ERROR: Invalid option for input format of the orbits file.  Try --help to see the command line options')
+
+    if (args.no < -1):
+        sys.exit('ERROR: Invalid option for number of orbits per config file.  Try --help to see the command line options')
+
+    if (args.day1 < 1):
+        sys.exit('ERROR: Invalid option for first day in survey to run.  Try --help to see the command line options')
+
+    if (args.ndays == 0) or (args.ndays < -1):
+        sys.exit('ERROR: Invalid option for number of days in survey to run.  Try --help to see the command line options')
+
+    # make config file
+    makeConfig(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/surveySimPP/utilities/makeMultiConfigOIF.py
+++ b/surveySimPP/utilities/makeMultiConfigOIF.py
@@ -34,18 +34,18 @@ def makeConfig(args):
     # get range of fields for those days
     field1 = database.loc[(database["observationStartMJD"] - day1) < 1.0]["observationId"].iloc[0]
     fieldf = database.loc[(database["observationStartMJD"] - dayf) < 2.0]["observationId"].iloc[-1]  # this will likely overshoot a little bit
-    
-    orbits_list = glob.glob(args.o+'orbits*.txt')
-    
+
+    orbits_list = glob.glob(args.o + 'orbits*.txt')
+
     for fn in orbits_list:
-        
+
         if (args.inputformat == 'whitespace'):
             orbits = pd.read_csv(fn, delim_whitespace=True)
         else:
             orbits = pd.read_csv(fn)
 
         nOrbitsTotal = len(orbits.index)
-        
+
         orbits_name = os.path.basename(os.path.splitext(fn)[0])[7:]
 
         config.read_dict({
@@ -80,8 +80,7 @@ def makeConfig(args):
             }
         })
 
-        ndigits = len(str(len(orbits.index)))
-        with open(args.o+'config_' + orbits_name + '.ini', 'w') as file:
+        with open(args.o + 'config_' + orbits_name + '.ini', 'w') as file:
             config.write(file)
 
 

--- a/surveySimPP/utilities/makeSLURMscript.py
+++ b/surveySimPP/utilities/makeSLURMscript.py
@@ -1,0 +1,78 @@
+import os
+import glob
+import argparse
+
+def makeSLURM(args):
+
+    configfiles = glob.glob(args.inputs + 'config_*.ini')
+    
+    if args.ncores:
+        numcores = args.ncores
+    else:
+        numcores = len(configfiles)
+
+    with open(args.filename, 'a') as the_file:
+        the_file.write('#!/bin/bash\n')
+        the_file.write('#SBATCH --job-name='+args.jobname+'\n')
+        the_file.write('#SBATCH --ntasks='+str(numcores)+'\n') 
+        the_file.write('\n')
+        the_file.write('\n')
+
+    for config in configfiles:
+        rootname = 'oif_' + os.path.basename(os.path.splitext(config)[0])[7:]
+    
+        os_command = 'nice -n 10 oif -f ' + config + ' > ' + args.oifout + rootname + '.txt &'
+    
+        with open(args.filename, 'a') as the_file:
+            the_file.write(os_command+'\n')
+
+    with open(args.filename, 'a') as the_file:
+        the_file.write('wait\n')
+
+    orbits = glob.glob(args.inputs+'orbits*.txt')
+
+    for orbits_fn in orbits:
+    
+        rootname = os.path.basename(os.path.splitext(orbits_fn)[0])[7:]
+    
+        colours_fn = args.inputs + 'colours_' + rootname + '.txt'
+        oif_fn = args.oifout + 'oif_' + rootname + '.txt'
+    
+        mkdir_command = 'mkdir ' + args.allout + rootname
+    
+        output_path = args.allout + rootname + '/'
+    
+        call_command = 'nice -n 10 surveySimPP -c {} -l {} -o {} -p {} -u {} -t {} -dw &'.format(args.ssppcon, 
+                                                                                      colours_fn, orbits_fn, 
+                                                                                      oif_fn, output_path, 
+                                                                                      rootname)
+                                                                                  
+        with open(args.filename, 'a') as the_file:
+            the_file.write(mkdir_command + '\n')
+            the_file.write(call_command + '\n')
+
+def main():
+
+    parser = argparse.ArgumentParser(description='Creating a SLURM script for OIF+SSPP.')
+    
+    # filepath/name to save script as
+    parser.add_argument('-f', '--filename', help='Filepath and name where you want to save the SLURM script.', type=str, required=True)
+    # path to inputs
+    parser.add_argument('-i', '--inputs', help='Path location of input text files (orbits, colours and config files). Default is current folder.', type=str, default="./")
+    # SSPP config pathname
+    parser.add_argument('-c', '--ssppcon', help='Name of SSPP config file. Default is PPConfig.ini', type=str, default='PPConfig.ini')
+    # path where oif output will be stored
+    parser.add_argument('-oo', '--oifout', help='Path where OIF output will be stored.', type=str, required=True)
+    # final output pathname
+    parser.add_argument('-ao', '--allout', help='Path where final output will be stored.', type=str, required=True)
+    # cores to utilise (default: one core per orbits input file)
+    parser.add_argument('-n', '--ncores', help='Number of cores. Default will be one core per orbits input file.', type=int, default=0)
+    # job name
+    parser.add_argument('-jn', '--jobname', help='Job name. Default is OIF+SSPP.', type=str, default='OIF+SSPP')
+    
+    args = parser.parse_args()
+    
+    makeSLURM(args)
+
+if __name__ == '__main__':
+    main()

--- a/surveySimPP/utilities/makeSLURMscript.py
+++ b/surveySimPP/utilities/makeSLURMscript.py
@@ -2,10 +2,11 @@ import os
 import glob
 import argparse
 
+
 def makeSLURM(args):
 
     configfiles = glob.glob(args.inputs + 'config_*.ini')
-    
+
     if args.ncores:
         numcores = args.ncores
     else:
@@ -13,48 +14,49 @@ def makeSLURM(args):
 
     with open(args.filename, 'a') as the_file:
         the_file.write('#!/bin/bash\n')
-        the_file.write('#SBATCH --job-name='+args.jobname+'\n')
-        the_file.write('#SBATCH --ntasks='+str(numcores)+'\n') 
+        the_file.write('#SBATCH --job-name=' + args.jobname + '\n')
+        the_file.write('#SBATCH --ntasks=' + str(numcores) + '\n')
         the_file.write('\n')
         the_file.write('\n')
 
     for config in configfiles:
         rootname = 'oif_' + os.path.basename(os.path.splitext(config)[0])[7:]
-    
+
         os_command = 'nice -n 10 oif -f ' + config + ' > ' + args.oifout + rootname + '.txt &'
-    
+
         with open(args.filename, 'a') as the_file:
-            the_file.write(os_command+'\n')
+            the_file.write(os_command + '\n')
 
     with open(args.filename, 'a') as the_file:
         the_file.write('wait\n')
 
-    orbits = glob.glob(args.inputs+'orbits*.txt')
+    orbits = glob.glob(args.inputs + 'orbits*.txt')
 
     for orbits_fn in orbits:
-    
+
         rootname = os.path.basename(os.path.splitext(orbits_fn)[0])[7:]
-    
+
         colours_fn = args.inputs + 'colours_' + rootname + '.txt'
         oif_fn = args.oifout + 'oif_' + rootname + '.txt'
-    
+
         mkdir_command = 'mkdir ' + args.allout + rootname
-    
+
         output_path = args.allout + rootname + '/'
-    
-        call_command = 'nice -n 10 surveySimPP -c {} -l {} -o {} -p {} -u {} -t {} -dw &'.format(args.ssppcon, 
-                                                                                      colours_fn, orbits_fn, 
-                                                                                      oif_fn, output_path, 
-                                                                                      rootname)
-                                                                                  
+
+        call_command = 'nice -n 10 surveySimPP -c {} -l {} -o {} -p {} -u {} -t {} -dw &'.format(args.ssppcon,
+                                                                                                 colours_fn, orbits_fn,
+                                                                                                 oif_fn, output_path,
+                                                                                                 rootname)
+
         with open(args.filename, 'a') as the_file:
             the_file.write(mkdir_command + '\n')
             the_file.write(call_command + '\n')
 
+
 def main():
 
     parser = argparse.ArgumentParser(description='Creating a SLURM script for OIF+SSPP.')
-    
+
     # filepath/name to save script as
     parser.add_argument('-f', '--filename', help='Filepath and name where you want to save the SLURM script.', type=str, required=True)
     # path to inputs
@@ -69,10 +71,11 @@ def main():
     parser.add_argument('-n', '--ncores', help='Number of cores. Default will be one core per orbits input file.', type=int, default=0)
     # job name
     parser.add_argument('-jn', '--jobname', help='Job name. Default is OIF+SSPP.', type=str, default='OIF+SSPP')
-    
+
     args = parser.parse_args()
-    
+
     makeSLURM(args)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Adding two utility scripts:

- makeMultiConfigOIF.py does the same thing as makeConfigOIF.py, but works with multiple orbits files that have already been split up by the user. (makeConfigOIF.py assumes one large orbits file.)

- makeSLURMscript.py does exactly what you'd expect: when told where to look for inputs and given output paths, it generates a basic template SLURM script for the user to perform parallel runs.

Example usage:

`makeMultiConfigOIF ./example_inputs_folder/ ./another_folder/baseline_v2.0_10yrs.db -no -1 -ndays -1 -camerafov instrument_circle.dat -spkstep 1`

`makeSLURMscript -f testslurmscript.sh -i ./example_inputs_folder/ -oo /test/oif_outputs_folder/ -ao /test/SSPP_outputs_folder/ -jn testjob`

setup.cfg has been edited accordingly. 

Also fixed a small error in makeConfigPP.py that didn't actually seem to cause any bugs, but it's fixed anyway.

Also:

Fixes #303. The default name for the intermediate ephemeris database now contains the date and the PID and will be reliably unique in the case of the user saving multiple inputs in the same folder.

Fixes #304. When reading from an existing intermediate database, the user now must also supply the filepath/filename as the command argument with the -dr flag.

Fixes #305. The command line argument -dl will delete the intermediate database after the code has run.

Error handling was added for the above and tested.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
