### PR TITLE
Issue #319.

### DIFF
--- a/demo/PPConfig_test.ini
+++ b/demo/PPConfig_test.ini
@@ -83,7 +83,9 @@ cameraModel = footprint
 # fillfactor = 0.9
 
 # Limit of brightness: detection with brightness higher than this are omitted (assuming saturation).
-# Must be a float.
+# This can be either a single float (in which case, the same saturation limit is applied for each filter)
+# or a comma-separated list of floats (one saturation limit per filter): the list must be the same length
+# as observing_filters.
 # Default == 16.0
 brightLimit = 16.0
 

--- a/surveySimPP/modules/PPBrightLimit.py
+++ b/surveySimPP/modules/PPBrightLimit.py
@@ -1,25 +1,45 @@
 #!/usr/bin/python
 
-# Author: Grigori Fedorets
+# Author: Steph Merritt
 
-def PPBrightLimit(padain, brlimit):
+def PPBrightLimit(observations, observing_filters, bright_limit):
 
     """
     Task: PPBrightLimit
 
-    Description: Goes through every row in pandas dataframe and drops lines the ColinFil
-    of which is brighter than the defined magnitude.
+    Description: Drops observations brighter than the user-defined saturation
+    limit. Can take either a single saturation limit for a straight cut, or
+    filter-specific saturation limits.
 
 
-    Input: padain: pandas dataframe
-    upperlimit: float, upper limit for ColinFil column value in padain dataframe
+    Input: observations: pandas dataframe
+    observing_filters: list of strings, observing filters in the data
+    bright_limit: either a float or a list of floats, saturation limits either
+    single or per-filter.
 
 
     Output: pandas dataframe (modified)
 
 
     """
-    padain = padain.drop(padain[padain.observedTrailedSourceMag < brlimit].index)
-    padain.reset_index(drop=True, inplace=True)
 
-    return padain
+    if type(bright_limit) is float:
+
+        observations_out = observations.drop(observations[observations['observedTrailedSourceMag'] < bright_limit].index)
+
+    elif type(bright_limit) is list:
+
+        drop_index = []
+
+        # get the index of everything brighter than its designated saturation limit in filter
+        for i, filt in enumerate(observing_filters):
+            ind = observations[(observations['optFilter'] == filt) & (observations['observedTrailedSourceMag'] < bright_limit[i])].index.values
+            drop_index.append(ind.tolist())
+
+        # then drop all at once (it's probably faster this way)
+        flat_index = [x for xs in drop_index for x in xs]
+        observations_out = observations.drop(flat_index)
+
+    observations_out.reset_index(drop=True, inplace=True)
+
+    return observations_out

--- a/surveySimPP/modules/PPCalculateApparentMagnitude.py
+++ b/surveySimPP/modules/PPCalculateApparentMagnitude.py
@@ -35,7 +35,6 @@ def PPCalculateApparentMagnitude(observations, phasefunction, mainfilter, otherc
         verboselog('Calculating cometary magnitude using a simple model and applying colour offset...')
         observations = PPCalculateSimpleCometaryMagnitude(observations, mainfilter, othercolours)
     else:
-
         # if user is only interested in one filter, we have no colour offsets to apply: assume H is in that filter
         if len(observing_filters) > 1:
             verboselog('Selecting and applying correct colour offset...')

--- a/surveySimPP/modules/tests/test_PPBrightLimit.py
+++ b/surveySimPP/modules/tests/test_PPBrightLimit.py
@@ -10,7 +10,7 @@ def test_PPBrightLimit():
     test_input = pd.read_csv(get_test_filepath("test_input_fullobs.csv"))
     test_output = pd.read_csv(get_test_filepath("test_output_PPBrightLimit.csv"))
 
-    test_result = PPBrightLimit(test_input, 20.0)
+    test_result = PPBrightLimit(test_input, 'r', 20.0)
 
     pd.testing.assert_frame_equal(test_output, test_result)
 

--- a/surveySimPP/modules/tests/test_PPRandomizeMeasurements.py
+++ b/surveySimPP/modules/tests/test_PPRandomizeMeasurements.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import numpy as np
+
+from surveySimPP.tests.data import get_test_filepath
+
+
+def test_randomizePhotometry():
+
+    from surveySimPP.modules.PPRandomizeMeasurements import randomizePhotometry
+
+    rng = np.random.default_rng(2021)
+
+    test_data = pd.read_csv(get_test_filepath('test_input_fullobs.csv'))
+
+    test_out = randomizePhotometry(test_data[0:1], rng, magName="TrailedSourceMag", sigName="PhotometricSigmaTrailedSource(mag)")
+
+    np.testing.assert_almost_equal(test_out.values[0], 19.654880, decimal=5)
+
+    return
+
+
+def test_randomizeAstrometry():
+
+    from surveySimPP.modules.PPRandomizeMeasurements import randomizeAstrometry
+
+    rng = np.random.default_rng(2021)
+
+    test_data = pd.read_csv(get_test_filepath('test_input_fullobs.csv'))
+
+    test_out = randomizeAstrometry(test_data[0:1], rng, sigName='AstrometricSigma(deg)', sigUnits='deg')
+
+    np.testing.assert_almost_equal(test_out[0][0], 164.03771597, decimal=5)
+    np.testing.assert_almost_equal(test_out[1][0], -17.58257153, decimal=5)
+
+    return

--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -155,7 +155,7 @@ def runLSSTPostProcessing(cmd_args):
 
         if configs['brightLimitOn']:
             verboselog('Dropping observations that are too bright...')
-            observations = PPBrightLimit(observations, configs['brightLimit'])
+            observations = PPBrightLimit(observations, configs['observing_filters'], configs['brightLimit'])
 
         if configs['SSPLinkingOn']:
             verboselog('Applying SSP linking filter...')


### PR DESCRIPTION
**Fixes #319.**

The brightness/saturation limit can now be either a single magnitude value (in which case it's applied to all filters) or a list of values the same length as observing_filters (in which case it applies a filter-specific saturation filter).

Also added error handling.

**Other changes:**

- Added unit tests for PPRandomizeMeasurements for both randomizePhotometry and randomizeAstrometry. This is the last of the higher priority unit tests - the rest are mostly for I/O functions and wrapper functions.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
