### PR TITLE
Issues #345, #337.

### DIFF
--- a/surveySimPP/modules/PPCommandLineParser.py
+++ b/surveySimPP/modules/PPCommandLineParser.py
@@ -27,9 +27,9 @@ def PPCommandLineParser(parser):
 
     cmd_args_dict = {}
 
-    cmd_args_dict['paramsinput'] = PPFindFileOrExit(args.l, '-l, --params')
+    cmd_args_dict['paramsinput'] = PPFindFileOrExit(args.l, '-p, --params')
     cmd_args_dict['orbinfile'] = PPFindFileOrExit(args.o, '-o, --orbit')
-    cmd_args_dict['oifoutput'] = PPFindFileOrExit(args.p, '-p, --pointing')
+    cmd_args_dict['oifoutput'] = PPFindFileOrExit(args.p, '-e, --ephem')
     cmd_args_dict['configfile'] = PPFindFileOrExit(args.c, '-c, --config')
     cmd_args_dict['outpath'] = PPFindFileOrExit(args.u, '-u, --outfile')
 

--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -51,7 +51,7 @@ def runLSSTPostProcessing(cmd_args):
     configs = PPConfigFileParser(cmd_args['configfile'], cmd_args['surveyname'])
 
     verboselog('Configuration file successfully read.')
-    
+
     configs['mainfilter'], configs['othercolours'] = PPGetMainFilterAndColourOffsets(cmd_args['paramsinput'],
                                                                                      configs['observing_filters'],
                                                                                      configs['filesep'])
@@ -128,6 +128,9 @@ def runLSSTPostProcessing(cmd_args):
         verboselog('Calculating effects of vignetting on limiting magnitude...')
         observations['fiveSigmaDepthAtSource'] = PPVignetting.vignettingEffects(observations)
 
+        verboselog('Applying field-of-view filters...')
+        observations = PPApplyFOVFilter(observations, configs, rng, verbose=cmd_args['verbose'])
+
         # Note that the below code creates observedTrailedSourceMag and observedPSFMag
         # as columns in the observations dataframe.
         # These are the columns that should be used moving forward for filters etc.
@@ -140,8 +143,9 @@ def runLSSTPostProcessing(cmd_args):
         observations["AstDecTrue(deg)"] = observations["AstDec(deg)"]
         observations["AstRA(deg)"], observations["AstDec(deg)"] = PPRandomizeMeasurements.randomizeAstrometry(observations, rng, sigName='AstrometricSigma(deg)', sigUnits='deg')
 
-        verboselog('Applying field-of-view filters...')
-        observations = PPApplyFOVFilter(observations, configs, rng, verbose=cmd_args['verbose'])
+        if configs['cameraModel'] == 'footprint':
+            verboselog('Re-applying field-of-view filters...')
+            observations = PPApplyFOVFilter(observations, configs, rng, verbose=cmd_args['verbose'])
 
         if configs['SNRLimitOn']:
             verboselog('Dropping observations with signal to noise ratio less than {}...'.format(configs['SNRLimit']))
@@ -220,9 +224,9 @@ def main():
     parser.add_argument("-dr", help="Location of existing/previous temporary ephemeris database to read from if wanted.", dest='dr', type=str)
     parser.add_argument("-dl", help="Delete the temporary ephemeris database after code has completed.", action='store_true', default=False)
     parser.add_argument("-m", "--comet", help="Comet parameter file name", type=str, dest='m')
-    parser.add_argument("-l", "--params", help="Physical parameters file name", type=str, dest='l', default='./data/params', required=True)
+    parser.add_argument("-p", "--params", help="Physical parameters file name", type=str, dest='l', default='./data/params', required=True)
     parser.add_argument("-o", "--orbit", help="Orbit file name", type=str, dest='o', default='./data/orbit.des', required=True)
-    parser.add_argument("-p", "--pointing", help="Pointing simulation output file name", type=str, dest='p', default='./data/oiftestoutput', required=True)
+    parser.add_argument("-e", "--ephem", help="Ephemeris simulation output file name", type=str, dest='p', default='./data/oiftestoutput', required=True)
     parser.add_argument("-s", "--survey", help="Survey to simulate", type=str, dest='s', default='LSST')
     parser.add_argument("-u", "--outfile", help="Path to store output and logs.", type=str, dest="u", default='./data/out/', required=True)
     parser.add_argument("-t", "--stem", help="Output file name stem.", type=str, dest="t", default='SSPPOutput')

--- a/surveySimPP/utilities/makeSLURMscript.py
+++ b/surveySimPP/utilities/makeSLURMscript.py
@@ -56,7 +56,7 @@ def makeSLURM(args):
 
         output_path = args.allout + rootname + '/'
 
-        call_command = 'nice -n 10 surveySimPP -c {} -l {} -o {} -p {} -u {} -t {} -dw &'.format(args.ssppcon,
+        call_command = 'nice -n 10 surveySimPP -c {} -p {} -o {} -e {} -u {} -t {} -dw &'.format(args.ssppcon,
                                                                                                  params_fn, orbits_fn,
                                                                                                  oif_fn, output_path,
                                                                                                  rootname)


### PR DESCRIPTION
Fixes #345.
The FOV filter is now run before and after the uncertainties are calculated.

Fixes #337.
This was fixed in a previous pull request but I was awaiting confirmation that nothing else needed to be moved.

NOTE:
I have also tidied up the command line flags for surveySimPP so that they make more sense. The NEW command to test-run SSPP is:

`surveySimPP -c ./demo/PPConfig_test.ini -p ./demo/sspp_testset_colours.txt -o ./demo/sspp_testset_orbits.des -e ./demo/example_oif_output.txt -u ./data/out/ -t testrun_e2e`

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
