### PR TITLE
Issues #361, #357.

### DIFF
--- a/surveySimPP/modules/PPGetLogger.py
+++ b/surveySimPP/modules/PPGetLogger.py
@@ -24,8 +24,8 @@ def PPGetLogger(
     dstr = datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
     cpid = os.getpid()
 
-    log_file_info = str(log_location + dstr + '-p' + str(cpid) + '-' + log_file_info)
-    log_file_error = str(log_location + dstr + '-p' + str(cpid) + '-' + log_file_error)
+    log_file_info = os.path.join(log_location, dstr + '-p' + str(cpid) + '-' + log_file_info)
+    log_file_error = os.path.join(log_location, dstr + '-p' + str(cpid) + '-' + log_file_error)
 
     file_handler_info = logging.FileHandler(log_file_info, mode='w')
     file_handler_info.setFormatter(log_formatter)

--- a/surveySimPP/modules/PPMakeTemporaryEphemerisDatabase.py
+++ b/surveySimPP/modules/PPMakeTemporaryEphemerisDatabase.py
@@ -84,9 +84,9 @@ def PPChunkedTemporaryDatabaseCreation(cnx, oif_output, chunkSize, delimiter):
             incrStep = n_rows - startChunk
 
         if delimiter == 'whitespace':
-            interm = PPSkipOifHeader(oif_output, 'ObjID', delim_whitespace=True, skiprows=range(1, startChunk + 1), nrows=incrStep, header=0)
+            interm = PPSkipOifHeader(oif_output, 'ObjID', delim_whitespace=True, skiprows=range(1, startChunk + 1), nrows=incrStep)
         elif delimiter == ',':
-            interm = PPSkipOifHeader(oif_output, 'ObjID', delimiter=',', skiprows=range(1, startChunk + 1), nrows=incrStep, header=0)
+            interm = PPSkipOifHeader(oif_output, 'ObjID', delimiter=',', skiprows=range(1, startChunk + 1), nrows=incrStep)
 
         interm.drop(['V', 'V(H=0)'], axis=1, inplace=True, errors='ignore')
         interm.to_sql("interm", con=cnx, if_exists="append", index=False)

--- a/surveySimPP/modules/PPReadOif.py
+++ b/surveySimPP/modules/PPReadOif.py
@@ -77,20 +77,21 @@ def PPSkipOifHeader(filename, line_start='ObjID', **kwargs):
     line, thus skipping the long OIF header.
     """
 
-    with open(filename) as f:
+    pplogger = logging.getLogger(__name__)
 
-        position = 0
-        current_line = f.readline()
+    found = 'no'
 
-        # reads the file line by line looking for the line that starts with
-        # the expected string
-        while not current_line.startswith(line_start):
-            position = f.tell()
-            current_line = f.readline()
+    with open(filename) as fh:
+        for i, line in enumerate(fh):
+            if line.startswith('ObjID'):
+                found = i
+                break
+            if i > 100:  # because we don't want to scan infinitely - OIF headers are ~30 lines long.
+                pplogger.error('ERROR: PPReadOif: column headings not found. Ensure column headings exist in OIF output and first column is ObjID.')
+                sys.exit('ERROR: PPReadOif: column headings not found. Ensure column headings exist in OIF output and first column is ObjID.')
 
-        # changes the file position to the start of the line that begins
-        # with the desired string
-        f.seek(position)
+    if found == 'no':
+        pplogger.error('ERROR: PPReadOif: column headings not found. Ensure column headings exist in OIF output and first column is ObjID.')
+        sys.exit('ERROR: PPReadOif: column headings not found. Ensure column headings exist in OIF output and first column is ObjID.')
 
-        # passes that file object to pandas
-        return pd.read_csv(f, **kwargs)
+    return pd.read_csv(filename, header=found, **kwargs)

--- a/surveySimPP/utilities/createTemporaryDatabases.py
+++ b/surveySimPP/utilities/createTemporaryDatabases.py
@@ -13,15 +13,24 @@ from surveySimPP.modules.PPMakeTemporaryEphemerisDatabase import PPMakeTemporary
 
 def make_temporary_databases(args):
 
+    print('Making temporary ephemerides databases.')
+
     input_path = os.path.abspath(args.inputs)
     file_list = glob.glob(os.path.join(input_path, args.stem) + '*')
+    output_list = [os.path.join(input_path, 'temp_' + os.path.basename(input_name).split('.')[0]) + '.db' for input_name in file_list]
+
+    if any([os.path.exists(out_name) for out_name in output_list]) and not args.f:
+        sys.exit('Temporary ephemeris databases already found in input location. Run with -f flag to overwrite.')
 
     if not file_list:
-        sys.exit('Could not find any files using given input path and stem.')
+        sys.exit('Could not find any ephemerides files using given input path and stem.')
 
     for input_name in file_list:
+        print('Creating temporary database for file: {}'.format(input_name))
         stem_filename = 'temp_' + os.path.basename(input_name).split('.')[0] + '.db'
         PPMakeTemporaryEphemerisDatabase(input_name, os.path.join(input_path, stem_filename), 'csv')
+
+    print('Done.')
 
 
 def main():
@@ -34,6 +43,8 @@ def main():
     parser.add_argument('-s', '--stem', help='Stem filename of input ephemeris text files. Default is "oif_".', type=str, default='oif_')
     # chunk size for creating databases
     parser.add_argument('-c', '--chunk', help="Chunking size for creation, where chunk=number of rows per chunk. Don't change this unless you know what you're doing.", type=int, default=1e6)
+    # force overwrite?
+    parser.add_argument("-f", "--force", help='Force deletion/overwrite of existing output file(s). Default False.', dest='f', action='store_true', default=False)
 
     args = parser.parse_args()
 

--- a/surveySimPP/utilities/makeConfigPP.py
+++ b/surveySimPP/utilities/makeConfigPP.py
@@ -4,6 +4,7 @@
 
 import argparse
 import configparser
+import os
 
 
 def makeConfigFile(args):
@@ -32,8 +33,8 @@ def makeConfigFile(args):
             {'cometactivity': args.cometactivity},
             'INPUTFILES':
             {'ephemerides_type': args.ephemeridestype,
-                'pointingdatabase': args.pointingdatabase,
-                'footprintPath': args.footprintpath,
+                'pointingdatabase': os.path.abspath(args.pointingdatabase),
+                'footprintPath': os.path.abspath(args.footprintpath),
                 'ppsqldbquery': args.ppsqldbquery,
                 'ephFormat': args.ephformat,
                 'auxFormat': args.auxformat},
@@ -56,7 +57,7 @@ def makeConfigFile(args):
 
     config.read_dict(config_dict)
 
-    with open(args.filename, 'w') as f:
+    with open(os.path.abspath(args.filename), 'w') as f:
         config.write(f)
 
 


### PR DESCRIPTION
**Fixes #361.**
The code will no longer get stuck in an infinite loop if the column headings do not exist in the OIF output file: it will instead error out gracefully.

**Fixes #357.**
makeSLURMscript.py now has flags to include only OIF or only SSPP.
createTemporaryDatabases.py logs to the console and also contains an option to force-overwrite: if it finds existing files and the -f flag is not set, it errors out.
makeConfigPP now saves absolute paths to the config file, to avoid any user confusion.

**Minor fix:**
PPGetLogger was not using os.path to resolve the filepath for the logs. I'd already changed every other function to make sure paths were resolved correctly - I'd missed this one.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
