### PR TITLE
Fixing database I/O.

### DIFF
--- a/surveySimPP/modules/PPMakeTemporaryEphemerisDatabase.py
+++ b/surveySimPP/modules/PPMakeTemporaryEphemerisDatabase.py
@@ -81,6 +81,7 @@ def PPChunkedTemporaryDatabaseCreation(cnx, oif_output, chunkSize, delimiter):
 
     while (endChunk <= n_rows):
         endChunk = int(startChunk + chunkSize)
+        print(startChunk, endChunk)
 
         if (n_rows - startChunk >= chunkSize):
             incrStep = chunkSize

--- a/surveySimPP/modules/PPMakeTemporaryEphemerisDatabase.py
+++ b/surveySimPP/modules/PPMakeTemporaryEphemerisDatabase.py
@@ -81,7 +81,6 @@ def PPChunkedTemporaryDatabaseCreation(cnx, oif_output, chunkSize, delimiter):
 
     while (endChunk <= n_rows):
         endChunk = int(startChunk + chunkSize)
-        print(startChunk, endChunk)
 
         if (n_rows - startChunk >= chunkSize):
             incrStep = chunkSize

--- a/surveySimPP/modules/PPReadOif.py
+++ b/surveySimPP/modules/PPReadOif.py
@@ -95,4 +95,11 @@ def PPSkipOifHeader(filename, line_start='ObjID', **kwargs):
         pplogger.error('ERROR: PPReadOif: column headings not found. Ensure column headings exist in OIF output and first column is ObjID.')
         sys.exit('ERROR: PPReadOif: column headings not found. Ensure column headings exist in OIF output and first column is ObjID.')
 
+    # cludge to make sure PPMakeTemporaryEphemerisDatabase works with chunking, sorry
+    if 'skiprows' in kwargs:
+        try:
+            kwargs['skiprows'] = range(kwargs['skiprows'][0] + found, kwargs['skiprows'][-1] + found + 1)
+        except IndexError:
+            pass
+
     return pd.read_csv(filename, header=found, **kwargs)


### PR DESCRIPTION
PPReadTemporaryEphemerisDatabase was taking a VERY long time with the new larger chunk sizes.

It was using a for-loop to pull objects one-by-one from the database. This was unnecessary. I've rewritten it. It now behaves as you'd expect: pulling 1000 objects from the database now takes 5 seconds, not _ten minutes_.

I also found a bug with the chunked creation of temporary ephemeris databases and how it interacts with PPSkipOifHeader. I have implemented a quick fix. In the future, I should probably rewrite PPSkipOifHeader to return only the row number of the column headings.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
