### PR TITLE
Small fixes.

### DIFF
--- a/surveySimPP/modules/PPBrightLimit.py
+++ b/surveySimPP/modules/PPBrightLimit.py
@@ -24,7 +24,7 @@ def PPBrightLimit(observations, observing_filters, bright_limit):
 
     if type(bright_limit) is float:
 
-        observations_out = observations.drop(observations[observations['observedTrailedSourceMag'] < bright_limit].index)
+        observations_out = observations.drop(observations[observations['observedPSFMag'] < bright_limit].index)
 
     elif type(bright_limit) is list:
 
@@ -32,7 +32,7 @@ def PPBrightLimit(observations, observing_filters, bright_limit):
 
         # get the index of everything brighter than its designated saturation limit in filter
         for i, filt in enumerate(observing_filters):
-            ind = observations[(observations['optFilter'] == filt) & (observations['observedTrailedSourceMag'] < bright_limit[i])].index.values
+            ind = observations[(observations['optFilter'] == filt) & (observations['observedPSFMag'] < bright_limit[i])].index.values
             drop_index.append(ind.tolist())
 
         # then drop all at once (it's probably faster this way)

--- a/surveySimPP/modules/PPConfigParser.py
+++ b/surveySimPP/modules/PPConfigParser.py
@@ -382,8 +382,8 @@ def PPConfigFileParser(configfile, survey_name):
 
     elif (config_dict['camera_model']) == 'circle':
 
-        config_dict['fill_factor'], _ = PPGetValueAndFlag(config, 'FILTERINGPARAMETERS', 'fillfactor', 'float')
-        config_dict['circle_radius'], _ = PPGetValueAndFlag(config, 'PERFORMANCE', 'circleRadius', 'float')
+        config_dict['fill_factor'], _ = PPGetValueAndFlag(config, 'FOV', 'fill_factor', 'float')
+        config_dict['circle_radius'], _ = PPGetValueAndFlag(config, 'FOV', 'circle_radius', 'float')
 
         if not config_dict['fill_factor'] and not config_dict['circle_radius']:
             pplogger.error('ERROR: either "fill_factor" or "circle_radius" must be specified for circular footprint.')

--- a/surveySimPP/modules/PPDetectionProbability.py
+++ b/surveySimPP/modules/PPDetectionProbability.py
@@ -47,7 +47,7 @@ def calcDetectionProbability(mag, limmag, fillFactor=1.0, w=0.1):
 
 
 def PPDetectionProbability(oif_df, trailing_losses=False, trailing_loss_name='dmagDetect',
-                           magnitude_name="observedTrailedSourceMag",
+                           magnitude_name="observedPSFMag",
                            limiting_magnitude_name="fiveSigmaDepthAtSource",
                            field_id_name="FieldID",
                            fillFactor=1.0, w=0.1):

--- a/surveySimPP/modules/PPMagnitudeLimit.py
+++ b/surveySimPP/modules/PPMagnitudeLimit.py
@@ -15,7 +15,7 @@ def PPMagnitudeLimit(observations, mag_limit):
 
     """
 
-    observations = observations[observations['observedTrailedSourceMag'] < mag_limit]
+    observations = observations[observations['observedPSFMag'] < mag_limit]
     observations.reset_index(drop=True, inplace=True)
 
     return observations

--- a/surveySimPP/modules/tests/test_PPBrightLimit.py
+++ b/surveySimPP/modules/tests/test_PPBrightLimit.py
@@ -15,7 +15,7 @@ def test_PPBrightLimit():
 
     observations = pd.DataFrame({'ObjID': observation_ID,
                                  'optFilter': observation_filter,
-                                 'observedTrailedSourceMag': observation_mag})
+                                 'observedPSFMag': observation_mag})
 
     observing_filters = ['r', 'g']
 

--- a/surveySimPP/modules/tests/test_PPMagnitudeLimit.py
+++ b/surveySimPP/modules/tests/test_PPMagnitudeLimit.py
@@ -6,10 +6,10 @@ from numpy.testing import assert_equal
 def test_PPMagnitudeLimit():
     from surveySimPP.modules.PPMagnitudeLimit import PPMagnitudeLimit
 
-    test_input = pd.DataFrame({'observedTrailedSourceMag': np.arange(15, 25)})
+    test_input = pd.DataFrame({'observedPSFMag': np.arange(15, 25)})
 
     test_output = PPMagnitudeLimit(test_input, 18.)
-    assert_equal(test_output['observedTrailedSourceMag'].values, [15, 16, 17])
+    assert_equal(test_output['observedPSFMag'].values, [15, 16, 17])
 
     test_zero = PPMagnitudeLimit(test_input, 14.)
     assert len(test_zero) == 0

--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -113,6 +113,11 @@ def runLSSTPostProcessing(cmd_args):
         observations = PPReadAllInput(cmd_args, configs, filterpointing,
                                       startChunk, incrStep, verbose=cmd_args['verbose'])
 
+        if len(observations) == 0:
+            verboselog('WARNING: no observations in merged dataframe. Skipping to next chunk...')
+            startChunk = startChunk + configs['size_serial_chunk']
+            continue
+
         verboselog('Calculating apparent magnitudes...')
         observations = PPCalculateApparentMagnitude(observations,
                                                     configs['phase_function'],

--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -115,7 +115,7 @@ def runLSSTPostProcessing(cmd_args):
         # If the ephemeris file doesn't have any observations for the objects in the chunk
         # PPReadAllInput will return an empty dataframe. We thus log a warning.
         if len(observations) == 0:
-            pplogger.info('WARNING: no observations in merged dataframe. Skipping to next chunk...')
+            pplogger.info('WARNING: no ephemeris observations found for these objects. Skipping to next chunk...')
             startChunk = startChunk + configs['size_serial_chunk']
             continue
 

--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -91,7 +91,6 @@ def runLSSTPostProcessing(cmd_args):
     # avoid memory overflow
     startChunk = 0
     endChunk = 0
-    # number of rows in an entire orbit file
 
     ii = -1
     with open(cmd_args['orbinfile']) as f:
@@ -113,8 +112,10 @@ def runLSSTPostProcessing(cmd_args):
         observations = PPReadAllInput(cmd_args, configs, filterpointing,
                                       startChunk, incrStep, verbose=cmd_args['verbose'])
 
+        # If the ephemeris file doesn't have any observations for the objects in the chunk
+        # PPReadAllInput will return an empty dataframe. We thus log a warning.
         if len(observations) == 0:
-            verboselog('WARNING: no observations in merged dataframe. Skipping to next chunk...')
+            pplogger.info('WARNING: no observations in merged dataframe. Skipping to next chunk...')
             startChunk = startChunk + configs['size_serial_chunk']
             continue
 

--- a/surveySimPP/utilities/makeConfigOIF.py
+++ b/surveySimPP/utilities/makeConfigOIF.py
@@ -154,7 +154,7 @@ def main():
     parser.add_argument("-mpcfile", help='name of the file containing the MPC observatory codes. Default value = obslist.dat', type=str, default='obslist.dat')
     parser.add_argument("-spkstep", help="Integration step in days. Default value = 30", type=int, default=30)
     parser.add_argument("-telescope", help="Observatory MPC Code. Default value = I11 (Gemini South to be changed to Rubin Observatory)", type=str, default='I11')
-    parser.add_argument("-query", help="SQL query for pointing database.", type=str, default="SELECT observationStartMJD, observationId FROM observations ORDER BY observationStartMJD")
+    parser.add_argument("-query", help="SQL query for pointing database.", type=str, default="SELECT observationId,observationStartMJD,fieldRA,fieldDEC,rotSkyPos FROM observations order by observationStartMJD")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Some small fixes to bugs found by me, Grigori and Jake.

- PPDetectionProbability (i.e. the fading function), PPMagnitudeLimit and PPBrightLimit were using observedTrailedSourceMag and not observedPSFMag (which is the magnitude corrected for trailing losses). I can only assume that I managed to get confused as to which was which at some point.
- The utility script makeConfigOIF.py had a really bad default for the SQL query that would never work. Changed it to one that will work for the majority of pointing databases.
- Two lines in PPConfigParser hadn't been correctly updated to reflect the changes I made to the config file.

Fixes #380.
- There may be cases where a chunk of objects in a large run may not actually have any OIF observations associated with them because they simply do not appear on the LSST fields. PPReadAllInput would in this case return an empty dataframe. This then led to an error in PPApplyColourOffsets. Since in this case the empty dataframe is intended behaviour, the code now checks to see if the dataframe is empty after PPReadAllInput, and if it is it puts a warning in the log then skips to the next chunk.
- This also triggers if the user somehow manages to supply an OIF file with ObjIDs that don't match the physical parameters/orbits file. There isn't really a way to distinguish between "empty dataframe because the user made a mistake" and "empty dataframe because this particular chunk of objects doesn't have any OIF observations", hence the warning message.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
