### PR TITLE
Improve run time of PPDropObservations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ docs/_build
 .tox
 .tmp
 .idea
+build/*

--- a/surveySimPP/modules/PPDropObservations.py
+++ b/surveySimPP/modules/PPDropObservations.py
@@ -20,7 +20,6 @@ def PPDropObservations(observations, rng, probability="detection probability"):
     num_obs = len(observations.index)
 
     uniform_distr = rng.random(num_obs)
-    drop = observations.loc[observations[probability] - uniform_distr < 0].index
-    out = observations.drop(drop)
+    out = observations[observations[probability] >= uniform_distr]
 
     return out


### PR DESCRIPTION
A small change to get familiar with the code. Speeds up PPDropObservations by 2x as measured by timeit (although admittedly PPDropObservations is not significant in the overall cost).

Also adds build directory to .gitignore.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions? [The change is covered by current unit tests]
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503) [No new errors, but some preexisting ones]
