### PR TITLE
Fixed up flake8 linting issues. Added a few `#noqa`s as appropriate.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@ Describe your changes.
 - [ ] Have you written a unit test for any new functions?
 - [ ] Do all the units tests run successfully?
 - [ ] Does SurveySimPP run successfully on a test set of input files/databases?
-- [ ] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
+- [ ] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E133,W503)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,8 @@
 #
 import os
 import sys
+from pkg_resources import get_distribution
+
 sys.path.insert(0, os.path.abspath('../'))
 
 # -- Project information -----------------------------------------------------
@@ -21,7 +23,6 @@ copyright = '2022'
 author = 'surveySimPP development team'
 
 # The full version, including alpha/beta/rc tags
-from pkg_resources import get_distribution
 release = get_distribution('surveySimPP').version
 
 
@@ -51,6 +52,4 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
-
-
+# html_static_path = ['_static']

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ console_scripts =
 test =
     pytest
     pytest-cov
+    flake8
 docs =
     sphinx
     sphinx-rtd-theme
@@ -72,3 +73,6 @@ filterwarnings =
 
 [flake8]
 max-line-length = 100
+extend-ignore = E501,E126,E228,E133,W503
+per-file-ignores =
+    surveySimPP/modules/__init__.py:F401

--- a/surveySimPP/__init__.py
+++ b/surveySimPP/__init__.py
@@ -1,2 +1,2 @@
-from . import modules
-from . import lsstcomet
+from . import modules  # noqa: F401
+from . import lsstcomet  # noqa: F401

--- a/surveySimPP/lsstcomet/__init__.py
+++ b/surveySimPP/lsstcomet/__init__.py
@@ -1,1 +1,1 @@
-from .model import *
+from .model import ChuryumovGerasimenko, Comet  # noqa: F401

--- a/surveySimPP/modules/benchmarks/bench_ApplyColourOffsets.py
+++ b/surveySimPP/modules/benchmarks/bench_ApplyColourOffsets.py
@@ -22,17 +22,21 @@ def setup_test_obs(num_copies=1):
     G = np.array([0.15, 0.15, 0.15, 0.15, 0.12, 0.12, 0.12, 0.12]*num_copies)
 
     return pd.DataFrame({'ObjID': objects, 'optFilter': optfilter,
-                                    'u-r': ur, 'g-r': gr, 'i-r': ir, 'z-r': zr,
-                                    'H_r': H, 'GS': G})
+                         'u-r': ur, 'g-r': gr, 'i-r': ir, 'z-r': zr,
+                         'H_r': H, 'GS': G})
+
 
 def setup_other_colors():
     return ['u-r', 'g-r', 'i-r', 'z-r']
 
+
 def setup_obs_filters():
     return ['r', 'u', 'g', 'i', 'z']
 
+
 def create_runtime_statement():
     return 'PPApplyColourOffsets(test_obs.copy(), "HG", othercolours, observing_filters, "r")'
+
 
 def create_setup_str(num_copies=1):
     return f'''
@@ -41,9 +45,8 @@ othercolours = setup_other_colors()
 observing_filters = setup_obs_filters()
 '''
 
-class TestBenchApplyColourOffsets:
-    
 
+class TestBenchApplyColourOffsets:
     '''Runtime benchmarking'''
     def test_bench_runtime(self):
 
@@ -58,12 +61,7 @@ class TestBenchApplyColourOffsets:
             t = timeit.Timer(
                 stmt=create_runtime_statement(),
                 setup=create_setup_str(n),
-                globals={
-                    'PPApplyColourOffsets': PPApplyColourOffsets,
-                    'setup_other_colors': setup_other_colors,
-                    'setup_test_obs': setup_test_obs,
-                    'setup_obs_filters': setup_obs_filters,
-                    },
+                globals=globals(),
                 )
 
             output = t.repeat(repeat=11, number=1)


### PR DESCRIPTION
Fixes # 397

Pre-factor work to clean up flake8 linting errors before starting to apply Python Project Template.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [ ] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E228,E133,W503)
