### PR TITLE
Adding `_build` to the list of excluded directories when building docs.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,5 +96,5 @@ repos:
             "-d", # Flag for cached environment and doctrees
             "./docs/_build/doctrees", # Directory
             "-D", # Flag to override settings in conf.py
-            "exclude_patterns=notebooks/*", # Exclude our notebooks from pre-commit
+            "exclude_patterns=notebooks/*,_build,**.ipynb_checkpoints", # Exclude our notebooks from pre-commit
           ]


### PR DESCRIPTION
Fixes #404.

When sphinx discovered which files to build, it was also looking in the output directory, `_build`, and thus it was creating a  deeply nested directory structure the more times the docs were built locally. 

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E133,W503)
