### PR TITLE
Added new benchmark script for PPDetectionEfficiency

### DIFF
--- a/src/surveySimPP/modules/benchmarks/bench_ApplyColourOffsets.py
+++ b/src/surveySimPP/modules/benchmarks/bench_ApplyColourOffsets.py
@@ -72,28 +72,29 @@ class TestBenchApplyColourOffsets:
     """Runtime benchmarking"""
 
     def test_bench_runtime(self):
-        for n in [1_000, 10_000]:
-            emitter = Emitter(
-                namespace="lsst.lf",
-                name="sspp.module_benchmarks",
-                module=PPApplyColourOffsets.__name__,
-                benchmark_type=f"run_{n}",
-                benchmark_unit="s",
-            )
+        num_copies = 1_000
 
-            t = timeit.Timer(
-                stmt=create_runtime_statement(),
-                setup=create_setup_str(n),
-                globals=globals(),
-            )
+        emitter = Emitter(
+            namespace="lsst.lf",
+            name="sspp.module_benchmarks",
+            module=PPApplyColourOffsets.__name__,
+            benchmark_type=f"run_{num_copies}",
+            benchmark_unit="s",
+        )
 
-            output = t.repeat(repeat=11, number=1)
+        t = timeit.Timer(
+            stmt=create_runtime_statement(),
+            setup=create_setup_str(num_copies),
+            globals=globals(),
+        )
 
-            # We take 11 samples, but we only emit the last 10.
-            # The first sample is considered a warm up.
-            for sample in output[1:]:
-                emitter.set_value(sample)
-                emitter.emit()
+        output = t.repeat(repeat=11, number=1)
+
+        # We take 11 samples, but we only emit the last 10.
+        # The first sample is considered a warm up.
+        for sample in output[1:]:
+            emitter.set_value(sample)
+            emitter.emit()
 
     """Memory usage benchmarking"""
 

--- a/src/surveySimPP/modules/benchmarks/bench_DetectionEfficiency.py
+++ b/src/surveySimPP/modules/benchmarks/bench_DetectionEfficiency.py
@@ -1,0 +1,49 @@
+import timeit
+import numpy as np
+import pandas as pd
+
+from metric_emitter import Emitter
+
+from surveySimPP.modules.PPDetectionEfficiency import PPDetectionEfficiency
+
+
+def setup_observations():
+    return pd.DataFrame({"ObjID": np.arange(0, 1_000_000)})
+
+
+def create_runtime_statement():
+    return "PPDetectionEfficiency(observations, 0.5, rng)"
+
+
+def create_setup_str():
+    return f"""
+observations = setup_observations()
+rng = np.random.default_rng(2021)
+"""
+
+
+class TestBenchDetectionEfficiency:
+    """Runtime benchmarking"""
+
+    def test_bench_runtime(self):
+        emitter = Emitter(
+            namespace="lsst.lf",
+            name="sspp.module_benchmarks",
+            module=PPDetectionEfficiency.__name__,
+            benchmark_type=f"run",
+            benchmark_unit="s",
+        )
+
+        t = timeit.Timer(
+            stmt=create_runtime_statement(),
+            setup=create_setup_str(),
+            globals=globals(),
+        )
+
+        output = t.repeat(repeat=11, number=1)
+
+        # We take 11 samples, but we only emit the last 10.
+        # The first sample is considered a warm up.
+        for sample in output[1:]:
+            emitter.set_value(sample)
+            emitter.emit()


### PR DESCRIPTION
This PR introduces a new benchmark script to check `PPDetectionEfficiency`. It also removes the larger benchmarks from the ApplyColourOffsets benchmark script. 

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does SurveySimPP run successfully on a test set of input files/databases?
- [x] Have you used flake8 on the files you have updated to confirm python programming style guide enforcement? (You can ignore line length warnings: flake8 --ignore=E501,E126,E228,E133,W503)
